### PR TITLE
fix: :bug: marketing pages dark mode

### DIFF
--- a/src/components/HomepageHero/index.tsx
+++ b/src/components/HomepageHero/index.tsx
@@ -5,21 +5,10 @@ import Translate from "@docusaurus/Translate";
 import HeroDesktopBg from "@site/static/img/hero-desktop.svg";
 import HeroMobileBg from "@site/static/img/hero-mobile.svg";
 import styles from "./styles.module.scss";
-import { useColorMode } from "@docusaurus/theme-common";
+import { useForcedDarkTheme } from "@site/src/utils/useForcedDarkTheme";
+
 export default function HomepageHero(): JSX.Element {
-  const { setColorMode, colorMode } = useColorMode();
-
-  //quick fix for updating color mode on page load breaking after theme upgrade
-  React.useEffect(() => {
-    const originalTheme = colorMode;
-
-    // The second parameter exists, it's just not on the type :(
-    setColorMode("dark", { persist: false });
-
-    return () => {
-      setColorMode(originalTheme);
-    };
-  }, []);
+  useForcedDarkTheme();
 
   return (
     <header className={clsx("bg-deep-sea text-white", styles.homepageHero)}>

--- a/src/components/PageHeader/index.tsx
+++ b/src/components/PageHeader/index.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import clsx from "clsx";
 import styles from "./styles.module.scss";
+import { useForcedDarkTheme } from "@site/src/utils/useForcedDarkTheme";
 
 type PageHeaderProps = {
   heading: string;
@@ -12,6 +13,7 @@ export default function PageHeader({
   heading,
   subheading,
 }: PageHeaderProps): JSX.Element {
+  useForcedDarkTheme();
   return (
     <header className={clsx("bg-11-o-clock text-white", styles.pageHeader)}>
       <div className="container">

--- a/src/utils/useForcedDarkTheme.ts
+++ b/src/utils/useForcedDarkTheme.ts
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { useColorMode } from "@docusaurus/theme-common";
+
+export function useForcedDarkTheme() {
+  const { setColorMode, colorMode } = useColorMode();
+  //quick fix for updating color mode on page load breaking after theme upgrade
+  React.useEffect(() => {
+    const originalTheme = colorMode;
+
+    // The second parameter exists, it's just not on the type :(
+    setColorMode("dark", { persist: false });
+
+    return () => {
+      setColorMode(originalTheme);
+    };
+  }, []);
+}

--- a/src/utils/usePrefersReducesMotion.ts
+++ b/src/utils/usePrefersReducesMotion.ts
@@ -6,7 +6,7 @@ export function usePrefersReducedMotion() {
 
   React.useEffect(() => {
     const prefersReducedMotion = window.matchMedia(
-      "(prefers-reduced-motion: reduce)"
+      "(prefers-reduced-motion: reduce)",
     ).matches;
     setPrefersReducedMotion(prefersReducedMotion);
   }, []);


### PR DESCRIPTION
Fixes request access global elements when going using light mode on docs and switching to request access