### PR TITLE
refactor: :wrench: Turn off contextual search for algolia

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -196,10 +196,13 @@ const config = {
         additionalLanguages: ["csharp", "java"],
       },
       algolia: {
-      // N.B. per Algolia, these are public values - once we get them, we can commit them to the open source repo.
-      appId: "7AS88HZE0W", //prod
-      apiKey: "a2570205a9dee84db0870157430e3d8a", //prod
-      indexName: "euid", //prod
+        // N.B. per Algolia, these are public values - once we get them, we can commit them to the open source repo.
+        appId: "7AS88HZE0W", //prod
+        apiKey: "a2570205a9dee84db0870157430e3d8a", //prod
+        indexName: "euid", //prod
+        //enabling due to possible indexing issue that needs to be corrected on the Algolia side
+        //https://docusaurus.io/docs/search#algolia-no-search-results
+        contextualSearch: false,
       },
     }),
 };


### PR DESCRIPTION
Turned off the contextual search for Algolia as there could possible be an indexing issue. Note, this should be fine for now, but if we want to add another language(s) or doc versioning, we will need to turn back to true and review the Algolia indexing. 


https://docusaurus.io/docs/search#contextual-search

https://docusaurus.io/docs/search#algolia-no-search-results