### PR TITLE
EUID fix admonitions to Docusaurus coding.

### DIFF
--- a/docs/endpoints/post-identity-buckets.md
+++ b/docs/endpoints/post-identity-buckets.md
@@ -17,7 +17,9 @@ Used by: This endpoint is used mainly by advertisers and data providers. For det
 
 `POST '{environment}/v2/identity/buckets'`
 
->IMPORTANT: You must encrypt all request using your secret. For details and Python script examples, see [Encrypting Requests and Decrypting Responses](../getting-started/gs-encryption-decryption.md).
+:::important
+You must encrypt all request using your secret. For details and Python script examples, see [Encrypting Requests and Decrypting Responses](../getting-started/gs-encryption-decryption.md).
+:::
 
 ### Path Parameters
 
@@ -31,7 +33,9 @@ The integration environment and the production environment require different <Li
 
 ### Unencrypted JSON Body Parameters
 
->IMPORTANT: You must include the following parameter as a key-value pair in the JSON body of a request when encrypting it.
+:::important
+You must include the following parameter as a key-value pair in the JSON body of a request when encrypting it.
+:::
 
 | Body Parameter | Data Type | Attribute | Description | Format |
 | :--- | :--- | :--- | :--- | :--- |

--- a/docs/endpoints/post-identity-buckets.md
+++ b/docs/endpoints/post-identity-buckets.md
@@ -18,7 +18,7 @@ Used by: This endpoint is used mainly by advertisers and data providers. For det
 `POST '{environment}/v2/identity/buckets'`
 
 :::important
-You must encrypt all request using your secret. For details and Python script examples, see [Encrypting Requests and Decrypting Responses](../getting-started/gs-encryption-decryption.md).
+You must encrypt all requests using your secret. For details and Python script examples, see [Encrypting Requests and Decrypting Responses](../getting-started/gs-encryption-decryption.md).
 :::
 
 ### Path Parameters

--- a/docs/endpoints/post-identity-buckets.md
+++ b/docs/endpoints/post-identity-buckets.md
@@ -25,7 +25,9 @@ Used by: This endpoint is used mainly by advertisers and data providers. For det
 | :--- | :--- | :--- | :--- |
 | `{environment}` | string | Required | Testing environment: `https://integ.euid.eu`<br/>Production environment: `https://prod.euid.eu`<br/>For a full list, including regional operators, see [Environments](../getting-started/gs-environments.md). |
 
->NOTE: The integration environment and the production environment require different API keys.
+:::note
+The integration environment and the production environment require different <Link href="../ref-info/glossary-uid#gl-api-key">API keys</Link>.
+:::
 
 ### Unencrypted JSON Body Parameters
 

--- a/docs/endpoints/post-identity-map.md
+++ b/docs/endpoints/post-identity-map.md
@@ -26,7 +26,9 @@ Here's what you need to know:
 
 `POST '{environment}/v2/identity/map'`
 
->IMPORTANT: You must encrypt all request using your secret. For details and Python script examples, see [Encrypting Requests and Decrypting Responses](../getting-started/gs-encryption-decryption.md).
+:::important
+You must encrypt all request using your secret. For details and Python script examples, see [Encrypting Requests and Decrypting Responses](../getting-started/gs-encryption-decryption.md).
+:::
 
 ### Path Parameters
 
@@ -40,7 +42,9 @@ The integration environment and the production environment require different <Li
 
 ###  Unencrypted JSON Body Parameters
 
->IMPORTANT: You must include only **one** of the following two conditional parameters as a key-value pair in the JSON body of the request when encrypting it.
+:::important
+You must include only **one** of the following two conditional parameters as a key-value pair in the JSON body of the request when encrypting it.
+:::
 
 | Body Parameter | Data Type | Attribute | Description |
 | :--- | :--- | :--- | :--- |

--- a/docs/endpoints/post-identity-map.md
+++ b/docs/endpoints/post-identity-map.md
@@ -34,7 +34,9 @@ Here's what you need to know:
 | :--- | :--- | :--- | :--- |
 | `{environment}` | string | Required | Testing environment: `https://integ.euid.eu`<br/>Production environment: `https://prod.euid.eu`<br/>For a full list, including regional operators, see [Environments](../getting-started/gs-environments.md). |
 
->NOTE: The integration environment and the production environment require different API keys.
+:::note
+The integration environment and the production environment require different <Link href="../ref-info/glossary-uid#gl-api-key">API keys</Link>.
+:::
 
 ###  Unencrypted JSON Body Parameters
 

--- a/docs/endpoints/post-identity-map.md
+++ b/docs/endpoints/post-identity-map.md
@@ -27,7 +27,7 @@ Here's what you need to know:
 `POST '{environment}/v2/identity/map'`
 
 :::important
-You must encrypt all request using your secret. For details and Python script examples, see [Encrypting Requests and Decrypting Responses](../getting-started/gs-encryption-decryption.md).
+You must encrypt all requests using your secret. For details and Python script examples, see [Encrypting Requests and Decrypting Responses](../getting-started/gs-encryption-decryption.md).
 :::
 
 ### Path Parameters

--- a/docs/endpoints/post-token-generate.md
+++ b/docs/endpoints/post-token-generate.md
@@ -28,7 +28,9 @@ Here's what you need to know about this endpoint requests:
 | :--- | :--- | :--- | :--- |
 | `{environment}` | string | Required | Testing environment: `https://integ.euid.eu`<br/>Production environment: `https://prod.euid.eu`<br/>For a full list, including regional operators, see [Environments](../getting-started/gs-environments.md). |
 
->NOTE: The integration environment and the production environment require different API keys.
+:::note
+The integration environment and the production environment require different <Link href="../ref-info/glossary-uid#gl-api-key">API keys</Link>.
+:::
 
 ### Unencrypted JSON Body Parameters
 

--- a/docs/endpoints/post-token-generate.md
+++ b/docs/endpoints/post-token-generate.md
@@ -12,7 +12,11 @@ Requests an EUID token generated from the email address provided by a user with 
 
 Used by: This endpoint is used mainly by publishers.
 
->IMPORTANT: Be sure to call this endpoint only when you have obtained legal basis to convert the user’s personal data to EUID tokens for targeted advertising. The `optout_check` parameter, required with a value of `1`, checks whether the user has opted out.
+:::important
+Be sure to call this endpoint only when you have obtained legal basis to convert the user’s personal data to EUID tokens for targeted advertising. The `optout_check` parameter, required with a value of `1`, checks whether the user has opted out.
+:::
+
+Rather than calling this endpoint directly, you could use one of the SDKs to manage it for you. For a summary of options, see [SDKs: Summary](../sdks/summary-sdks.md).
 
 ## Request Format 
 
@@ -34,7 +38,9 @@ The integration environment and the production environment require different <Li
 
 ### Unencrypted JSON Body Parameters
 
->IMPORTANT: You must include only **one** of the following two conditional parameters, plus the required `optout_check` parameter with a value of `1`, as key-value pairs in the JSON body of the request when encrypting it.
+:::important
+You must include only **one** of the following two conditional parameters, plus the required `optout_check` parameter with a value of `1`, as key-value pairs in the JSON body of the request when encrypting it.
+:::
 
 | Body Parameter | Data Type | Attribute | Description | 
 | :--- | :--- | :--- | :--- |
@@ -45,7 +51,9 @@ The integration environment and the production environment require different <Li
 
 ### Request Examples
 
->IMPORTANT: To ensure that the API key used to access the service remains secret, the `POST&nbsp;/token/generate` endpoint must be called from the server side, unlike the [POST&nbsp;/token/refresh](post-token-refresh.md), which does not require using an API key.
+:::important
+To ensure that the API key used to access the service remains secret, the `POST&nbsp;/token/generate` endpoint must be called from the server side, unlike the [POST&nbsp;/token/refresh](post-token-refresh.md), which does not require using an API key.
+:::
 
 The following are unencrypted JSON request body examples for each parameter, one of which you should include in your token generation requests:
 

--- a/docs/endpoints/post-token-refresh.md
+++ b/docs/endpoints/post-token-refresh.md
@@ -13,7 +13,9 @@ Generate a new EUID token by sending the corresponding unexpired refresh token, 
 
 Used by: This endpoint is used mainly by publishers.
 
->NOTE: This endpoint can be called from the client side (for example, a browser or a mobile app) because it does not require using an API key.
+:::note
+This endpoint can be called from the client side (for example, a browser or a mobile app) because it does not require using an API key.
+:::
 
 ## Request Format 
 
@@ -32,7 +34,9 @@ Here's what you need to know about this endpoint:
 | :--- | :--- | :--- | :--- |
 | `{environment}` | string | Required | Testing environment: `https://integ.euid.eu`<br/>Production environment: `https://prod.euid.eu`<br/>For a full list, including regional operators, see [Environments](../getting-started/gs-environments.md). |
 
->NOTE: The integration environment and the production environment require different API keys.
+:::note
+The integration environment and the production environment require different <Link href="../ref-info/glossary-uid#gl-api-key">API keys</Link>.
+:::
 
 #### Testing Notes
 

--- a/docs/endpoints/post-token-validate.md
+++ b/docs/endpoints/post-token-validate.md
@@ -12,7 +12,9 @@ Validate that an advertising token matches the specified hashed or unhashed emai
 
 Used by: This endpoint is used mainly by publishers.
 
->NOTE: This endpoint is intended primarily for testing and troubleshooting new integrations.
+:::note
+This endpoint is intended primarily for testing and troubleshooting new integrations.
+:::
 
 ## Request Format 
 
@@ -27,7 +29,9 @@ Used by: This endpoint is used mainly by publishers.
 | :--- | :--- | :--- | :--- |
 | `{environment}` | string | Required | Testing environment: `https://integ.euid.eu`<br/>Production environment: `https://prod.euid.eu`<br/>For a full list, including regional operators, see [Environments](../getting-started/gs-environments.md). |
 
->NOTE: The integration environment and the production environment require different API keys.
+:::note
+The integration environment and the production environment require different <Link href="../ref-info/glossary-uid#gl-api-key">API keys</Link>.
+:::
 
 ### Unencrypted JSON Body Parameters
 
@@ -44,7 +48,9 @@ Used by: This endpoint is used mainly by publishers.
 
 The following are unencrypted JSON request body examples for each parameter, which you need to include in your token validation requests:
 
->NOTE: The advertising tokens in these examples are fictitious, for illustrative purposes only. The values provided are not real values.
+:::note
+The advertising tokens in these examples are fictitious, for illustrative purposes only. The values provided are not real values.
+:::
 
 ```json
 {

--- a/docs/endpoints/post-token-validate.md
+++ b/docs/endpoints/post-token-validate.md
@@ -20,8 +20,9 @@ This endpoint is intended primarily for testing and troubleshooting new integrat
 
 `POST '{environment}/v2/token/validate'`
 
->IMPORTANT: You must encrypt all requests, using your secret key. For details and Python script examples, see [Encrypting Requests and Decrypting Responses](../getting-started/gs-encryption-decryption.md).
-
+:::important
+You must encrypt all requests, using your secret key. For details and Python script examples, see [Encrypting Requests and Decrypting Responses](../getting-started/gs-encryption-decryption.md).
+:::
 
 ### Path Parameters
 

--- a/docs/getting-started/gs-account-setup.md
+++ b/docs/getting-started/gs-account-setup.md
@@ -38,7 +38,9 @@ All participants will need to provide at least the following information:
 
 If you're a publisher, and you determine that you want to implement EUID so that tokens are generated on the client side, you'll also need to provide a list of **domain names** for your sites. This is a security measure, for client-side implementation only.
 
->TIP: Only root-level domains are required for account setup. For example, if you're going to implement EUID to generate tokens on the client side on example.eu, shop.example.eu, and example.org, you only need to provide the domain names example.eu and example.org.
+:::tip
+Only root-level domains are required for account setup. For example, if you're going to implement EUID to generate tokens on the client side on example.eu, shop.example.eu, and example.org, you only need to provide the domain names example.eu and example.org.
+:::
 
 ## Credentials
 

--- a/docs/getting-started/gs-encryption-decryption.md
+++ b/docs/getting-started/gs-encryption-decryption.md
@@ -141,7 +141,9 @@ This section includes an encryption and decryption code example in different pro
 
 For the [POST&nbsp;/token/refresh](../endpoints/post-token-refresh.md) endpoint, the code takes the values for `refresh_token` and `refresh_response_key` that were obtained from a prior call to [POST&nbsp;/token/generate](../endpoints/post-token-generate.md) or [POST&nbsp;/token/refresh](../endpoints/post-token-refresh.md).
 
->NOTE: For Windows, if you're using Windows Command Prompt instead of PowerShell, you must also remove the single quotes surrounding the JSON. For example, use `echo {"email": "test@example.com"}`.
+:::note
+For Windows, if you're using Windows Command Prompt instead of PowerShell, you must also remove the single quotes surrounding the JSON. For example, use `echo {"email": "test@example.com"}`.
+:::
 
 ### Prerequisites and Notes
 

--- a/docs/getting-started/gs-environments.md
+++ b/docs/getting-started/gs-environments.md
@@ -20,7 +20,7 @@ All EUID endpoints use the same base URL.
 
 For example, https://integ.euid.eu/v2/token/generate
 
-NOTES:
+Notes:
 
 - All EUID endpoints use the same base URL.
 - The integration environment and the production environment require different <Link href="../ref-info/glossary-uid#gl-api-key">API keys</Link>.

--- a/docs/getting-started/gs-environments.md
+++ b/docs/getting-started/gs-environments.md
@@ -23,5 +23,5 @@ For example, https://integ.euid.eu/v2/token/generate
 NOTES:
 
 - All EUID endpoints use the same base URL.
-- The integration environment and the production environment require different API keys.
+- The integration environment and the production environment require different <Link href="../ref-info/glossary-uid#gl-api-key">API keys</Link>.
 - The expiration time of the EUID token returned by  the [POST&nbsp;/token/generate](../endpoints/post-token-generate.md) or [POST&nbsp;/token/refresh](../endpoints/post-token-refresh.md) endpoints is subject to change, but is always significantly shorter in the integration environment than it is in the production environment.

--- a/docs/getting-started/gs-faqs.md
+++ b/docs/getting-started/gs-faqs.md
@@ -151,7 +151,9 @@ We do not make any promises about when the rotation takes place. To stay as up-t
 
 Not necessarily. After you remap emails associated with a particular bucket ID, the emails might be assigned to a different bucket ID. To check the bucket ID, [call the mapping function](../guides/advertiser-dataprovider-guide.md#1-retrieve-a-raw-euid-for-personal-data-using-the-identity-map-endpoint) and save the returned EUID and bucket ID again.
 
->IMPORTANT: When mapping and remapping emails, be sure not to make any assumptions of the number of buckets, their specific rotation dates, or to which bucket an email gets assigned. 
+:::important
+When mapping and remapping emails, be sure not to make any assumptions of the number of buckets, their specific rotation dates, or to which bucket an email gets assigned.
+::: 
 
 #### How often should EUIDs be refreshed for incremental updates?
 
@@ -167,7 +169,9 @@ The system should follow the [email normalization rules](../getting-started/gs-n
 
 Yes. Not storing email address or hash mappings may increase processing time drastically when you have to map millions of addresses. Recalculating only those mappings that actually need to be updated, however, reduces the total processing time because only about 1/365th of EUIDs need to be updated daily.
 
->IMPORTANT: Unless you are using a private operator, you must map email addresses or hashes consecutively, using a single HTTP connection, in batches of  5,000 emails at a time. In other words, do your mapping without creating multiple parallel connections. 
+:::important
+Unless you are using a private operator, you must map email addresses or hashes consecutively, using a single HTTP connection, in batches of  5,000 emails at a time. In other words, do your mapping without creating multiple parallel connections.
+:::
 
 #### How should I handle user opt-outs?
 

--- a/docs/getting-started/gs-faqs.md
+++ b/docs/getting-started/gs-faqs.md
@@ -143,7 +143,9 @@ Here are some frequently asked questions for advertisers and data providers usin
 
 Metadata supplied with the EUID generation request indicates the salt bucket used for generating the EUID. Salt buckets persist and correspond to the underlying personal data used to generate an EUID. Use the  [POST&nbsp;/identity/buckets](../endpoints/post-identity-buckets.md) endpoint to return which salt buckets rotated since a given timestamp. The returned rotated salt buckets inform you which EUIDs to refresh.
 
->NOTE: We do not make any promises about when the rotation takes place. To stay as up-to-date as possible, we recommend doing the checks once per hour.
+:::note
+We do not make any promises about when the rotation takes place. To stay as up-to-date as possible, we recommend doing the checks once per hour.
+:::
 
 #### Do refreshed emails get assigned to the same bucket with which they were previously associated?
 

--- a/docs/getting-started/gs-normalization-encoding.md
+++ b/docs/getting-started/gs-normalization-encoding.md
@@ -63,7 +63,9 @@ An email hash is a Base64-encoded SHA-256 hash of a normalized email address. Th
 | SHA-256 hash of normalized email address | `b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514` | This 64-character string is a hex-encoded representation of the 32-byte SHA-256.|
 | Hex to Base64 SHA-256 encoding of normalized email address | `tMmiiTI7IaAcPpQPFQ65uMVCWH8av9jw4cwf/F5HVRQ=` | This 44-character string is a Base64-encoded representation of the 32-byte SHA-256.<br/>WARNING: The SHA-256 hash string in the example above is a hex-encoded representation of the hash value. You must Base64-encode the raw bytes of the hash or use a Base64 encoder that takes a hex-encoded value as input.<br/>Use this encoding for `email_hash` values sent in the request body. |
 
->WARNING: When applying Base64 encoding, be sure to Base64-encode the raw bytes of the hash or use a Base64 encoder that takes a hex-encoded value as input.
+:::warning
+When applying Base64 encoding, be sure to Base64-encode the raw bytes of the hash or use a Base64 encoder that takes a hex-encoded value as input.
+:::
 
 For additional examples, see [Normalization Examples for Email](#normalization-examples-for-email).
 

--- a/docs/getting-started/gs-normalization-encoding.md
+++ b/docs/getting-started/gs-normalization-encoding.md
@@ -34,7 +34,9 @@ EUID supports the following type of personal data:
 
 If you send unhashed email addresses to the EUID Operator Service, the service normalizes the email addresses and then hashes them. If you want to hash the email addresses yourself before sending them, you must normalize them before you hash them.
 
-> IMPORTANT: Normalizing before hashing ensures that the generated EUID value will always be the same, so that the data can be matched. If you do not normalize before hashing, this might result in a different EUID, reducing the effectiveness of targeted advertising.
+:::important
+Normalizing before hashing ensures that the generated EUID value will always be the same, so that the data can be matched. If you do not normalize before hashing, this might result in a different EUID, reducing the effectiveness of targeted advertising.
+:::
 
 To normalize an email address, complete the following steps:
 
@@ -49,7 +51,9 @@ To normalize an email address, complete the following steps:
     
        For example, normalize `janedoe+home@gmail.com` to `janedoe@gmail.com`.
 
->IMPORTANT: Make sure that the normalized email is UTF-8, not another encoding system such as UTF-16.
+:::warning
+Make sure that the normalized email is UTF-8, not another encoding system such as UTF-16.
+:::
 
 For examples of various scenarios, see [Normalization Examples for Email](#normalization-examples-for-email).
 
@@ -63,7 +67,7 @@ An email hash is a Base64-encoded SHA-256 hash of a normalized email address. Th
 | SHA-256 hash of normalized email address | `b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514` | This 64-character string is a hex-encoded representation of the 32-byte SHA-256.|
 | Hex to Base64 SHA-256 encoding of normalized email address | `tMmiiTI7IaAcPpQPFQ65uMVCWH8av9jw4cwf/F5HVRQ=` | This 44-character string is a Base64-encoded representation of the 32-byte SHA-256.<br/>WARNING: The SHA-256 hash string in the example above is a hex-encoded representation of the hash value. You must Base64-encode the raw bytes of the hash or use a Base64 encoder that takes a hex-encoded value as input.<br/>Use this encoding for `email_hash` values sent in the request body. |
 
-:::warning
+:::important
 When applying Base64 encoding, be sure to Base64-encode the raw bytes of the hash or use a Base64 encoder that takes a hex-encoded value as input.
 :::
 

--- a/docs/getting-started/gs-permissions.md
+++ b/docs/getting-started/gs-permissions.md
@@ -13,7 +13,9 @@ The EUID ecosystem includes several different API permissions that allow access 
 
 For each EUID participant that has API Key and Client Secret, the permissions are linked to the participant's API credentials (see [Account Setup](gs-account-setup.md) and [EUID Credentials](gs-credentials.md)).
 
->NOTE: If you're a publisher and are implementing EUID on the client side, API permissions do not apply to you. Instead, you'll receive a different set of credentials that are specifically for generating a client-side token request. For details, see [Subscription ID and Public Key](gs-credentials.md#subscription-id-and-public-key).
+:::note
+If you're a publisher and are implementing EUID on the client side, API permissions do not apply to you. Instead, you'll receive a different set of credentials that are specifically for generating a client-side token request. For details, see [Subscription ID and Public Key](gs-credentials.md#subscription-id-and-public-key).
+:::
 
 A participant can have one or several sets of API credentials with associated permissions. In cases where you have more than one API permission, you have the option to have a separate set of credentials for each permission or have a single set of credentials for all permissions. We recommend having a separate set of credentials for each permission. 
 

--- a/docs/guides/advertiser-dataprovider-guide.md
+++ b/docs/guides/advertiser-dataprovider-guide.md
@@ -53,7 +53,9 @@ A raw EUID is an identifier for a user at a specific moment in time. The raw EUI
 
 Even though each salt bucket is updated approximately once a year, individual bucket updates are spread over the year. Approximately 1/365th of all salt buckets are rotated daily.
 
->IMPORTANT: To ensure that your integration has the current raw EUIDs, check salt bucket rotation for active users every day.
+:::important
+To ensure that your integration has the current raw EUIDs, check salt bucket rotation for active users every day.
+:::
 
 | Step | Endpoint | Description |
 | --- | --- | --- |

--- a/docs/guides/custom-publisher-integration.md
+++ b/docs/guides/custom-publisher-integration.md
@@ -82,7 +82,9 @@ Consider how you want to manage EUID identity information and use it for targete
 | :--- | :--- | :--- |
 | 2-a | N/A| Send the `advertising_token` from step [1-e](#establish-identity-capture-user-data) to the SSP for bidding. Send the value as is. |
 
->NOTE: For an example of what an EUID token might look like in the bidstream, when it's sent from an SSP to a DSP, see [What does an EUID token look like in the bidstream?](../getting-started/gs-faqs.md#what-does-an-euid-token-look-like-in-the-bidstream).
+:::note
+For an example of what an EUID token might look like in the bidstream, when it's sent from an SSP to a DSP, see [What does an EUID token look like in the bidstream?](../getting-started/gs-faqs.md#what-does-an-euid-token-look-like-in-the-bidstream).
+:::
 
 ### Refresh an EUID Token
 

--- a/docs/guides/custom-publisher-integration.md
+++ b/docs/guides/custom-publisher-integration.md
@@ -47,7 +47,9 @@ This guide provides information for the last two options.
 
 
 
->TIP: To facilitate the process of establishing client identity using EUID and retrieving EUID tokens, consider using the EUID SDK for JavaScript. For details, see [Client-Server Integration Guide for JavaScript](integration-javascript-server-side.md).
+:::tip
+To facilitate the process of establishing client identity using EUID and retrieving EUID tokens, consider using the EUID SDK for JavaScript. For details, see [Client-Server Integration Guide for JavaScript](integration-javascript-server-side.md).
+:::
 
 ## Integration Steps
 
@@ -97,7 +99,9 @@ Use the `POST&nbsp;/token/refresh` endpoint to make sure you always have a valid
 | 3-c | [POST&nbsp;/token/refresh](../endpoints/post-token-refresh.md) | The EUID service issues a new identity token for users that haven't opted out. |
 | 3-d | N/A| Place the returned `advertising_token` and `refresh_token` in a store tied to a user. You may consider client-side storage like a first-party cookie or server-side storage. |
 
->TIP: Refresh tokens starting from the `refresh_from` timestamp on the identity returned by the [POST&nbsp;/token/generate](../endpoints/post-token-generate.md) or [POST&nbsp;/token/refresh](../endpoints/post-token-refresh.md) calls. 
+:::tip
+Refresh tokens starting from the `refresh_from` timestamp on the identity returned by the [POST&nbsp;/token/generate](../endpoints/post-token-generate.md) or [POST&nbsp;/token/refresh](../endpoints/post-token-refresh.md) calls.
+:::
 
 ### Clear Identity: User Logout
 

--- a/docs/guides/dsp-guide.md
+++ b/docs/guides/dsp-guide.md
@@ -16,7 +16,9 @@ DSPs receive EUID tokens in bid requests, and decrypt the EUID tokens to arrive 
 
 For a summary of available server-side SDKs, see [SDKs: Summary](../sdks/summary-sdks.md).
 
->NOTE: If your back end is written in a language not covered by one of the available server-side SDKs, ask your EUID contact in case there is additional information available to help you. If you're not sure who to ask, see [Contact Info](../getting-started/gs-account-setup.md#contact-info).
+:::note
+If your back end is written in a language not covered by one of the available server-side SDKs, ask your EUID contact in case there is additional information available to help you. If you're not sure who to ask, see [Contact Info](../getting-started/gs-account-setup.md#contact-info).
+:::
 
 <!-- It includes the following sections:
 

--- a/docs/guides/integration-javascript-server-side.md
+++ b/docs/guides/integration-javascript-server-side.md
@@ -167,7 +167,9 @@ The bidding step is shown in the following table.
 | :--- | :--- | :--- |
 | 2-a | EUID SDK for JavaScript | Gets the current user's advertising token by using the [getAdvertisingToken() function](../sdks/client-side-identity.md#getadvertisingtoken-string) as shown below. |
 
->NOTE: For an example of what an EUID token might look like in the bidstream, when it's sent from an SSP to a DSP, see [What does an EUID token look like in the bidstream?](../getting-started/gs-faqs.md#what-does-an-euid-token-look-like-in-the-bidstream)
+:::note
+For an example of what an EUID token might look like in the bidstream, when it's sent from an SSP to a DSP, see [What does an EUID token look like in the bidstream?](../getting-started/gs-faqs.md#what-does-an-euid-token-look-like-in-the-bidstream).
+:::
 
 ```html
 <script>
@@ -175,7 +177,9 @@ The bidding step is shown in the following table.
 </script>
 ```
 
->NOTE: You need to consider how you pass the returned advertising token to SSPs. With some other approaches to client-side EUID implementation, such as using `Prebid.js` (see [EUID Integration Overview for Prebid.js](integration-prebid.md)), the implementation includes functions that manage passing the returned advertising token. If you're using the EUID SDK for JavaScript you'll need to manage this yourself.
+:::note
+You need to consider how you pass the returned advertising token to SSPs. With some other approaches to client-side EUID implementation, such as using `Prebid.js` (see [EUID Integration Overview for Prebid.js](integration-prebid.md)), the implementation includes functions that manage passing the returned advertising token. If you're using the EUID SDK for JavaScript you'll need to manage this yourself.
+:::
 
 >TIP: Instead of calling `__euid.getAdvertisingToken()`, you can use the `advertising_token` property of the identity passed to the callback that you set up for step 1-g. The callback will be called every time the identity changes.
 

--- a/docs/guides/integration-javascript-server-side.md
+++ b/docs/guides/integration-javascript-server-side.md
@@ -42,7 +42,9 @@ For a workflow diagram, see [Integration Steps](#integration-steps). See also [F
 
 To facilitate the process of establishing client identity using EUID and retrieving advertising tokens, the web integration steps provided in this guide rely on the EUID SDK for JavaScript. Here's an [example application](https://example-jssdk-integ.uidapi.com/) that illustrates the integration steps described in this guide and the usage of the SDK (currently only for email addresses). For the application documentation, see [SDK Integration Example](https://github.com/IABTechLab/uid2-examples/blob/main/publisher/standard/README.md).
 
->TIP: The first-party cookie and local storage implementation details might change in the future. To avoid potential issues, be sure to rely on the functionality documented in the [EUID SDK for JavaScript API Reference](../sdks/client-side-identity.md#api-reference) for your identity management.
+:::tip
+The first-party cookie and local storage implementation details might change in the future. To avoid potential issues, be sure to rely on the functionality documented in the [EUID SDK for JavaScript API Reference](../sdks/client-side-identity.md#api-reference) for your identity management.
+:::
 
 For integration scenarios for publishers that do not use the EUID SDK for JavaScript, see [Publisher Integration Guide, Server-Only](custom-publisher-integration.md). 
 
@@ -149,7 +151,9 @@ After authentication in step 1-c, which forces the user to accept the rules of e
 
 The SDK invokes the specified [callback function](../sdks/client-side-identity.md#callback-function) (which indicates the identity availability) and makes the established identity available client-side for bidding. 
 
->TIP: Depending on the structure of your code, it might be convenient to combine the callbacks for steps 1-f and 1-g into a single callback function.
+:::tip
+Depending on the structure of your code, it might be convenient to combine the callbacks for steps 1-f and 1-g into a single callback function.
+:::
 
 ### Bid Using EUID Tokens
 
@@ -181,7 +185,9 @@ For an example of what an EUID token might look like in the bidstream, when it's
 You need to consider how you pass the returned advertising token to SSPs. With some other approaches to client-side EUID implementation, such as using `Prebid.js` (see [EUID Integration Overview for Prebid.js](integration-prebid.md)), the implementation includes functions that manage passing the returned advertising token. If you're using the EUID SDK for JavaScript you'll need to manage this yourself.
 :::
 
->TIP: Instead of calling `__euid.getAdvertisingToken()`, you can use the `advertising_token` property of the identity passed to the callback that you set up for step 1-g. The callback will be called every time the identity changes.
+:::tip
+Instead of calling `__euid.getAdvertisingToken()`, you can use the `advertising_token` property of the identity passed to the callback that you set up for step 1-g. The callback will be called every time the identity changes.
+:::
 
 ### Refresh Tokens
 

--- a/docs/guides/operator-guide-aws-marketplace.md
+++ b/docs/guides/operator-guide-aws-marketplace.md
@@ -258,7 +258,9 @@ Here's what you need to know about upgrading:
 - Information on the availability of new versions is provided on the [European Unified ID Operator on AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-hhxu72nnzzmnm) page.
 - To upgrade your EUID Operators, create a new CloudFormation stack. For details, see [Deployment](#deployment).
 
->TIP: For a smooth transition, create the new stack first. After the new stack is bootstrapped and ready to serve, delete the old stack. If you are using a load balancer, first get the new instances up and running and then convert the DNS name from the previous one to the new one.
+:::tip
+For a smooth transition, create the new stack first. After the new stack is bootstrapped and ready to serve, delete the old stack. If you are using a load balancer, first get the new instances up and running and then convert the DNS name from the previous one to the new one.
+:::
 
 ## Technical Support
 

--- a/docs/guides/operator-guide-aws-marketplace.md
+++ b/docs/guides/operator-guide-aws-marketplace.md
@@ -32,7 +32,9 @@ The EUID Operator is the API server in the EUID ecosystem. For a Private Operato
 
 ## EUID Private Operator for AWS Product
 
->NOTE: [European Unified ID Private Operator for AWS](https://aws.amazon.com/marketplace/pp/prodview-hhxu72nnzzmnm) is a free product. The cost displayed on the product page is an estimated cost for the necessary infrastructure.
+:::note
+[European Unified ID Private Operator for AWS](https://aws.amazon.com/marketplace/pp/prodview-hhxu72nnzzmnm) is a free product. The cost displayed on the product page is an estimated cost for the necessary infrastructure.
+:::
 
 By subscribing to the European Unified ID Operator on AWS Marketplace product, you gain access to the following:
 
@@ -139,7 +141,9 @@ Here's what you can customize during or after the [deployment](#deployment):
 
 ### Security Group Policy
 
->NOTE: To avoid passing certificates associated with your domain into the enclave, inbound HTTP is allowed instead of HTTPS. This also avoids the cost of a secure layer, if used in a private network that is internal to your organization. 
+:::note
+To avoid passing certificates associated with your domain into the enclave, inbound HTTP is allowed instead of HTTPS. This also avoids the cost of a secure layer, if used in a private network that is internal to your organization.
+:::
 
 | Port Number | Direction | Protocol | Description |
 | ----------- | --------- | -------- | ------ |

--- a/docs/guides/operator-guide-aws-marketplace.md
+++ b/docs/guides/operator-guide-aws-marketplace.md
@@ -52,7 +52,7 @@ To subscribe and deploy one or more EUID Operators on AWS, complete the followin
 
 #### Minimal IAM Role Privileges
 
->IMPORTANT: To succeed in a one-click deployment, your AWS account must have the privileges to run the following actions:
+To succeed in a one-click deployment, your AWS account **must** have the privileges to run the following actions:
 
 ```json
 {

--- a/docs/guides/publisher-client-side.md
+++ b/docs/guides/publisher-client-side.md
@@ -108,7 +108,10 @@ __euid.init({
   baseUrl: "https://integ.euid.eu",
 });
 ```
->NOTE: Tokens from the EUID integration environment are not valid for passing to the bidstream. For the integration environment, you will have different **subscription ID** and **public key** values.
+
+:::note
+Tokens from the EUID integration environment are not valid for passing to the bidstream. For the integration environment, you will have different **subscription ID** and **public key** values.
+:::
 
 ### Optional: Reduce Latency by Setting the API Base URL for the Production Environment
 

--- a/docs/guides/publisher-client-side.md
+++ b/docs/guides/publisher-client-side.md
@@ -56,7 +56,9 @@ Complete the EUID account setup by following the steps described in the [Account
 
 When account setup is complete, you'll receive a **public key** and **subscription ID**. These values are unique to you, and you'll use them to configure the EUID module.
 
->TIP: Only root-level domains are required for account setup. For example, if you're going to use the EUID SDK for JavaScript on example.com, shop.example.com, and example.org, you only need to provide the domain names example.com and example.org.
+:::tip
+Only root-level domains are required for account setup. For example, if you're going to use the EUID SDK for JavaScript on example.com, shop.example.com, and example.org, you only need to provide the domain names example.com and example.org.
+:::
 
 ## Add SDK for JavaScript to Your Site
 
@@ -215,7 +217,9 @@ In this scenario:
 
 After calling one of the methods listed in [Configure the SDK for JavaScript](#configure-the-sdk-for-javascript) successfully, an identity is generated and stored in local storage, under the key `EUID-sdk-identity`. The SDK refreshes the EUID token periodically.
 
->WARNING: The format of the object stored in local storage could change without notice. We recommend that you do **not** read and update the object in local storage directly. 
+:::warning
+The format of the object stored in local storage could change without notice. We recommend that you do **not** read and update the object in local storage directly.
+:::
 
 ## Example Integration Code and When to Pass Personal Data to the EUID SDK
 

--- a/docs/guides/summary-guides.md
+++ b/docs/guides/summary-guides.md
@@ -25,8 +25,9 @@ Integrations fall into these categories:
 
 The following resources are available for publisher integrations.
 
-<!-- >TIP: For a detailed summary of web integration options, see Web Integration Overview ../guides/integration-options-publisher-web.md.
--->
+:::tip
+For a detailed summary of web integration options, see [Web Integration Overview](../guides/integration-options-publisher-web.md).
+:::
 
 | Integration Guide | Content Description |
 | :--- | :--- |

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -19,7 +19,9 @@ The term "EUID" can refer to either the framework or an actual identifier. Unles
 
 EUID is an open-source, standalone solution with its own unique namespace that builds on the [UID2 framework](https://unifiedid.com/docs/intro). The main differences between UID2 and EUID result from more stringent European and UK data protection laws, relating to consent practices, rights for data subjects, and obligations between participants. Otherwise, EUID follows the same [guiding principles](#guiding-principles) as UID2.
 
->IMPORTANT: Even though it is built on the UID2 framework, EUID is a separate framework. 
+:::important
+Even though it is built on the UID2 framework, EUID is a separate framework.
+:::
 
 The following table summarizes the key differences between the two frameworks.
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -11,7 +11,9 @@ import Link from '@docusaurus/Link';
 
 The European Unified ID (EUID) is a framework that enables deterministic identity for advertising opportunities on the open internet for many [participants](#participants) across the advertising ecosystem. The EUID framework enables logged-in experiences from publisher websites, mobile apps, and Connected TV (CTV) apps to monetize through programmatic workflows. Built on the [UID2 framework](https://unifiedid.com/docs/intro), EUID offers the user transparency and privacy controls designed to meet market requirements in Europe and the UK.
 
->NOTE: The term "EUID" can refer to either the framework or an actual identifier. Unless otherwise indicated, this page provides an overview of the EUID framework.
+:::note
+The term "EUID" can refer to either the framework or an actual identifier. Unless otherwise indicated, this page provides an overview of the EUID framework.
+:::
 
 ### EUID vs. UID2
 

--- a/docs/overviews/overview-publishers.md
+++ b/docs/overviews/overview-publishers.md
@@ -83,9 +83,9 @@ The following resources are available for publishers to implement EUID:
 
 The following resources are available for publisher web integrations.
 
-<!-- :::tip
+:::tip
 For a detailed summary of web integration options, see [Web Integration Overview](../guides/integration-options-publisher-web.md).
-::: -->
+:::
 
 | Integration Type| Documentation | Content Description |
 | :--- | :--- | :--- |

--- a/docs/sdks/client-side-identity-v2.md
+++ b/docs/sdks/client-side-identity-v2.md
@@ -144,7 +144,9 @@ Here's what you need to know about the token auto-refresh:
 
 Constructs a EUID object.
 
->TIP: Instead of calling this function, you can just use the global `__euid` object. 
+:::tip
+Instead of calling this function, you can just use the global `__euid` object.
+:::
 
 ### init(opts: object): void
 
@@ -290,7 +292,10 @@ If the `getAdvertisingTokenAsync()` function is called *after* the initializatio
     .catch(err => { /* advertising token not available */ });
 </script>
 ```
->TIP: You can use this function to be notified of the completion of the SDK for JavaScript initialization from a component that might not be the one that called `init()`.
+
+:::tip
+You can use this function to be notified of the completion of the SDK for JavaScript initialization from a component that might not be the one that called `init()`.
+:::
 
 ### isLoginRequired(): boolean
 

--- a/docs/sdks/client-side-identity-v2.md
+++ b/docs/sdks/client-side-identity-v2.md
@@ -130,7 +130,7 @@ Here's what you need to know about the token auto-refresh:
 
 ## API Reference
 
-All interactions with the Client-Side JavaScript SDK are done through the global `__euid` object, which is a member of the `EUID` class. All of the following JavaScript functions are members of the `EUID` class. 
+All interactions with the Client-Side JavaScript SDK are done through the global `__euid` object, which is a member of the `EUID` class. All of the following JavaScript functions are members of the `EUID` class:
 
 - [constructor()](#constructor)
 - [init()](#initopts-object-void)

--- a/docs/sdks/client-side-identity-v2.md
+++ b/docs/sdks/client-side-identity-v2.md
@@ -279,7 +279,9 @@ This function can be called before or after the [init()](#initopts-object-void) 
 - If the advertising token is available, the promise is fulfilled with the current advertising token.
 - If the advertising token is not available, even temporarily, the promise is rejected with an instance of `Error`. To determine the best course of action in this case, you can use [isLoginRequired()](#isloginrequired-boolean).
 
->NOTE: If the `getAdvertisingTokenAsync()` function is called *after* the initialization is complete, the promise is settled immediately based on the current state.
+:::note
+If the `getAdvertisingTokenAsync()` function is called *after* the initialization is complete, the promise is settled immediately based on the current state.
+:::
 
 ```html
 <script>

--- a/docs/sdks/client-side-identity-v2.md
+++ b/docs/sdks/client-side-identity-v2.md
@@ -130,7 +130,7 @@ Here's what you need to know about the token auto-refresh:
 
 ## API Reference
 
->IMPORTANT: All interactions with the Client-Side JavaScript SDK are done through the global `__euid` object, which is a member of the `EUID` class. All of the following JavaScript functions are members of the `EUID` class. 
+All interactions with the Client-Side JavaScript SDK are done through the global `__euid` object, which is a member of the `EUID` class. All of the following JavaScript functions are members of the `EUID` class. 
 
 - [constructor()](#constructor)
 - [init()](#initopts-object-void)
@@ -238,7 +238,9 @@ The `object` parameter includes the following properties.
 
 The [callback function](#callback-function) returns the `status` field values as numbers from the `EUID.IdentityStatus` enum, which can be turned into the corresponding strings by calling `EUID.IdentityStatus[state.status]`. The following table lists the string values for the `status` enum.
 
->IMPORTANT: The following values are intended only to inform you of identity availability. Do not use them in conditional logic. 
+:::important
+The following values are intended only to inform you of identity availability. Do not use them in conditional logic.
+:::
 
 | Status | Advertising Token Availability | Description |
 | :--- | :--- | :--- |
@@ -369,4 +371,7 @@ The following is an example of the EUID cookie structure:
    }
 }
 ```
->IMPORTANT: The contents of the `private` object are explicitly unspecified and are left for the SDK to interpret. Do not make any assumptions about the structure, semantics, or compatibility of this object. Any updates to the cookie must retain its structure.
+
+:::important
+The contents of the `private` object are explicitly unspecified and are left for the SDK to interpret. Do not make any assumptions about the structure, semantics, or compatibility of this object. Any updates to the cookie must retain its structure.
+:::

--- a/docs/sdks/client-side-identity.md
+++ b/docs/sdks/client-side-identity.md
@@ -250,7 +250,7 @@ At any time after `init` has completed, you can call [`setIdentity`](#setidentit
 ## API Reference
 
 :::info
-All interactions with the EUID SDK for JavaScript are done through the global `__euid` object, which is an instance of the `EUID` class. All of the following JavaScript functions are members of the `EUID` class.
+All interactions with the EUID SDK for JavaScript are done through the global `__euid` object, which is an instance of the `EUID` class. All of the following JavaScript functions are members of the `EUID` class:
 :::
 
 - [constructor()](#constructor)

--- a/docs/sdks/sdk-ref-cplusplus.md
+++ b/docs/sdks/sdk-ref-cplusplus.md
@@ -62,7 +62,9 @@ The initialization function configures the parameters necessary for the SDK to a
 
 The interface allows you to decrypt EUID advertising tokens and return the corresponding raw EUID. 
 
->NOTE: When you use an SDK, you do not need to store or manage decryption keys.
+:::note
+When you use an SDK, you do not need to store or manage decryption keys.
+:::
 
 If you're a DSP, for bidding, call the interface to decrypt an EUID advertising token and return the EUID. For details on the bidding logic for handling user opt-outs, see [DSP Integration Guide](../guides/dsp-guide.md).
 

--- a/docs/sdks/sdk-ref-csharp-dotnet.md
+++ b/docs/sdks/sdk-ref-csharp-dotnet.md
@@ -63,7 +63,9 @@ The initialization function configures the parameters necessary for the SDK to a
 
 The interface allows you to decrypt EUID advertising tokens and return the corresponding raw EUID. 
 
->NOTE: When you use an SDK, you do not need to store or manage decryption keys.
+:::note
+When you use an SDK, you do not need to store or manage decryption keys.
+:::
 
 If you're a DSP, for bidding, call the interface to decrypt an EUID advertising token and return the EUID. For details on the bidding logic for handling user opt-outs, see [DSP Integration Guide](../guides/dsp-guide.md).
 

--- a/docs/sdks/sdk-ref-java.md
+++ b/docs/sdks/sdk-ref-java.md
@@ -327,7 +327,9 @@ If you're using server-only integration (see [Publisher Integration Guide, Serve
    IdentityMapResponse identityMapResponse = identityMapClient.generateIdentityMap(IdentityMapInput.fromEmails(Arrays.asList("email1@example.com", "email2@example.com")));
    ```
 
->Note: The SDK hashes input values before sending them. This ensures that raw email addresses and phone numbers do not leave your server.
+:::note
+The SDK hashes input values before sending them. This ensures that raw email addresses and phone numbers do not leave your server.
+:::
 
 3. Retrieve the mapped and unmapped results as follows:
    ```java

--- a/docs/sdks/sdk-ref-python.md
+++ b/docs/sdks/sdk-ref-python.md
@@ -198,7 +198,9 @@ If you're using server-only integration (see [Publisher Integration Guide, Serve
    identity_map_response = client.generate_identity_map(IdentityMapInput.from_emails(["email1@example.com", "email2@example.com"]))
    ```
 
->Note: The SDK hashes input values before sending them. This ensures that raw email addresses do not leave your server.
+:::note
+The SDK hashes input values before sending them. This ensures that raw email addresses do not leave your server.
+:::
 
 3. Retrieve the mapped and unmapped results as follows:
    ```py


### PR DESCRIPTION
- All admonitions fixed to Docusaurus MD except those after break tags in tables (where Docu coding is not valid).
- Minor edits and updates to correspond with the UID2 files and style guidelines.