### PR TITLE
fix typo in Request Access page meta description

### DIFF
--- a/src/pages/request-access.tsx
+++ b/src/pages/request-access.tsx
@@ -26,7 +26,7 @@ const componentData = {
   }),
   description: translate({
     id: "requestAccess.metaDescription",
-    message: "Contact us to become a EUID partner.",
+    message: "Contact us to become an EUID partner.",
     description: "The request access page meta description",
   }),
   heading: translate({


### PR DESCRIPTION
fix typo in Request Access page meta description (Marketing page)