### PR TITLE
iOS SDK doc for EUID

### DIFF
--- a/docs/overviews/overview-publishers.md
+++ b/docs/overviews/overview-publishers.md
@@ -110,7 +110,7 @@ The following resources are available for publisher integrations supporting mobi
 
 | Integration Type| Documentation | Content Description |
 | :--- | :--- | :--- |
-| iOS | [SDK for iOS Reference Guide](../sdks/sdk-ref-ios.md) | An SDK that facilitates the process of generating or establishing client identity using UID2 and retrieving EUID tokens for publishers that need to support iOS apps. |
+| iOS | [SDK for iOS Reference Guide](../sdks/sdk-ref-ios.md) | An SDK that facilitates the process of generating or establishing client identity using EUID and retrieving EUID tokens for publishers that need to support iOS apps. |
 
 ### Prebid Integrations
 

--- a/docs/overviews/overview-publishers.md
+++ b/docs/overviews/overview-publishers.md
@@ -80,6 +80,7 @@ To get started, follow these steps:
 The following resources are available for publishers to implement EUID:
 
 - [Web Integrations](#web-integrations)
+- [Mobile Integrations](#mobile-integrations)
 - [Prebid Integrations](#prebid-integrations)
 
 ### Web Integrations
@@ -99,6 +100,14 @@ For a detailed summary of web integration options, see [Web Integration Overview
 | JavaScript Client-Side Integration | [Client-Side Integration Guide for JavaScript](../guides/integration-javascript-client-side.md) | A guide for publishers who want to integrate with EUID using only client-side JavaScript changes, which is the easiest implementation approach.<br/>The SDK for JavaScript manages token generation and token refresh automatically. |
 | JavaScript Client-Server Integration | [Client-Server Integration Guide for JavaScript](../guides/integration-javascript-client-server.md) | A publisher guide covering standard web integration scenarios that use the SDK for JavaScript and require tokens to be generated on the server side and passed to the publisher web pages. |
 | Server-Side Integration | [Publisher Integration Guide, Server-Side](../guides/integration-publisher-server-side.md) | A guide for publishers who do not use the [SDK for JavaScript](../sdks/sdk-ref-javascript.md). |
+
+### Mobile Integrations
+
+The following resources are available for publisher integrations supporting Android or iOS devices.
+
+| Integration Type| Documentation | Content Description |
+| :--- | :--- | :--- |
+| iOS | [SDK for iOS Reference Guide](../sdks/sdk-ref-ios.md) | An SDK that facilitates the process of generating or establishing client identity using UID2 and retrieving EUID tokens for publishers that need to support iOS apps. |
 
 ### Prebid Integrations
 

--- a/docs/sdks/sdk-ref-ios.md
+++ b/docs/sdks/sdk-ref-ios.md
@@ -46,7 +46,7 @@ You'll be granted permission to use specific functions offered by the SDK, and g
 
 <!-- As of 7 May 2024 -->
 
-This documentation is for the SDK for iOS version 1.2.0 and later.
+This documentation is for the SDK for iOS version 1.7.0 and later.
 
 For current and past release notes information, see [https://github.com/IABTechLab/uid2-ios-sdk/releases](https://github.com/IABTechLab/uid2-ios-sdk/releases).
 
@@ -81,7 +81,7 @@ Add the following dependency to Package.swift:
 
 ```js
 dependencies: [
-  .package(url: "https://github.com/IABTechLab/uid2-ios-sdk.git", from: "1.2.0"),
+  .package(url: "https://github.com/IABTechLab/uid2-ios-sdk.git", from: "1.7.0"),
 ]
 ```
 
@@ -91,7 +91,7 @@ In the XCode user interface, under Package Dependencies, add the following entry
 
 | Name | Location | Dependency Rule                         |
 | :--- | :--- |:----------------------------------------| 
-| uid2-ios-sdk | `git@github.com:IABTechLab/uid2-ios-sdk.git` | Up to next major version: 1.2.0 < 2.0.0 |
+| uid2-ios-sdk | `git@github.com:IABTechLab/uid2-ios-sdk.git` | Up to next major version: 1.7.0 < 2.0.0 |
 
 ### Installing with CocoaPods
 
@@ -196,4 +196,3 @@ The `Identity` variable stores and returns the current `UID2Identity` data objec
 #### identityStatus
 
 The `identityStatus` variable stores and returns the status of the current EUID Identity being managed by the SDK.
-

--- a/docs/sdks/sdk-ref-ios.md
+++ b/docs/sdks/sdk-ref-ios.md
@@ -1,0 +1,197 @@
+---
+title: SDK for iOS
+description: Reference information about the iOS SDK.
+hide_table_of_contents: false
+sidebar_position: 14
+---
+
+import Link from '@docusaurus/Link';
+
+# SDK for iOS Reference Guide
+
+You can use the SDK for iOS for the following:
+
+- Generating or establishing client identity using EUID.
+- Retrieving advertising tokens for <Link href="../ref-info/glossary-uid#gl-bidstream">bidstream</Link> use.
+- Automatically refreshing EUID tokens.
+
+The following iOS-related plugins, and associated documentation, are also available:
+
+| Purpose | Product/Documentation |
+| :--- | :--- |
+| To use the Google Mobile Ads (GMA) SDK to send <Link href="../ref-info/glossary-uid#gl-euid-token">EUID tokens</Link> as [secure signals](https://support.google.com/admob/answer/11556288) in ad requests from iOS/tvOS apps | [EUID GMA Plugin for iOS Integration Guide](../guides/mobile-plugin-gma-ios.md) |
+| To use the Google Interactive Media Ads SDK for iOS to send <Link href="../ref-info/glossary-uid#gl-euid-token">EUID tokens</Link> as [secure signals](https://support.google.com/admob/answer/11556288) in ad requests from iOS/tvOS apps | [EUID IMA Plugin for iOS Integration Guide](../guides/mobile-plugin-ima-ios.md) |
+
+## tvOS Support
+Although this page refers to SDK for iOS, this SDK also supports tvOS. For the required tvOS version, see [Minimum Requirements](#minimum-requirements).
+
+## Functionality
+
+This SDK simplifies integration with EUID for any publishers who want to support EUID for apps running on iOS devices. The following table shows the functions it supports.
+
+| Encrypt Raw EUID to EUID Token | Decrypt EUID Token to Raw EUID | Generate EUID Token from DII | Refresh EUID Token | Map Personal Data to Raw EUID |
+| :--- | :--- | :--- | :--- | :--- |
+| &#8212; | &#8212; | &#9989; | &#9989; | &#8212; |
+
+The SDK for iOS is designed to generate and/or manage EUID identity on behalf of iOS apps. It enables EUID identity to be persisted across app lifecycles by securely storing the identity on a device via platform-native encryption tools.
+
+By default, the SDK automatically refreshes EUID identity based on expiration dates. However, you can disable this to allow implementing apps to manage the EUID identity lifecycle manually.
+
+## API Permissions
+
+To use this SDK, you'll need to complete the EUID account setup by following the steps described in the [Account Setup](../getting-started/gs-account-setup.md) page.
+You'll be granted permission to use specific functions offered by the SDK, and given credentials for that access.
+
+## SDK Version
+
+<!-- As of 7 May 2024 -->
+
+This documentation is for the SDK for iOS version 1.2.0 and later.
+
+For current and past release notes information, see [https://github.com/IABTechLab/uid2-ios-sdk/releases](https://github.com/IABTechLab/uid2-ios-sdk/releases).
+
+## GitHub Open-Source Repository
+
+This SDK is in the following open-source GitHub repository:
+
+- [https://github.com/IABTechLab/uid2-ios-sdk](https://github.com/IABTechLab/uid2-ios-sdk)
+
+## Minimum Requirements
+
+Minimum requirements for this SDK are as follows:
+
+- Xcode version: 15.0+
+- iOS	minimum target version: 13.0+
+- tvOS minimum target version: 13.0+
+- Swift version: 5.0+
+
+<!-- See also: [Requirements](https://github.com/IABTechLab/uid2-ios-sdk/blob/main/README.md#requirements). -->
+
+## Installation
+
+Install the iOS SDK via Swift Package Manager (SPM) or CocoaPods. There are three installation options:
+
+-   [Package.swift](#installing-with-packageswift)
+-   [Xcode](#installing-with-xcode)
+-   [CocoaPods](#installing-with-cocoapods)
+
+### Installing with Package.swift
+
+Add the following dependency to Package.swift:
+
+```js
+dependencies: [
+  .package(url: "https://github.com/IABTechLab/uid2-ios-sdk.git", from: "1.2.0"),
+]
+```
+
+### Installing with Xcode
+
+In the XCode user interface, under Package Dependencies, add the following entry for your apps:
+
+| Name | Location | Dependency Rule                         |
+| :--- | :--- |:----------------------------------------| 
+| uid2-ios-sdk | `git@github.com:IABTechLab/uid2-ios-sdk.git` | Up to next major version: 1.2.0 < 2.0.0 |
+
+### Installing with CocoaPods
+
+Add the following entry in your `Podfile`:
+
+```
+pod 'UID2', '~> 1.2'
+```
+
+## Usage Guidelines
+
+The **UID2Manager** singleton is the primary developer API for the SDK for iOS. It is responsible for storing, refreshing, and retrieving the EUID Identity including the EUID token.
+
+For iOS, the `UID2Manager` is initialized automatically the first time it is accessed. You can configure it to support automatic or manual refresh capabilities.
+
+There are two ways to establish an initial EUID Identity:
+
+1. Generate the EUID identity using DII&#8212;email (hashed or unhashed) or phone number (hashed or unhashed). For integration instructions, see [Client-Side Integration Guide for Mobile](../guides/integration-mobile-client-side.md).
+
+2. Create an EUID identity from your server's back end and then pass it to the EUID SDK. For integration instructions, see [Client-Server Integration Guide for Mobile](../guides/integration-mobile-client-server).
+
+The EUID Mobile SDKs can perform refreshes of EUID identities, after an Identity is established. This is because the refresh functionality relies on the refresh tokens that are part of the EUID Identity.
+
+
+## Code Samples
+
+The following code samples provide examples of performing specific activities relating to managing EUID with the SDK for iOS.
+
+Generate an initial EUID Identity (for instructions, see [Client-Side Integration Guide for Mobile](../guides/integration-mobile-client-side#configure-the-uid2-mobile-sdk)):
+
+```js
+UID2Manager.shared.generateIdentity(
+    _ identity: IdentityType,
+    subscriptionID: String,
+    serverPublicKey: String,
+    appName: String? = nil
+)
+```
+Set the Initial EUID Identity (for instructions, see [Client-Server Integration Guide for Mobile](../guides/integration-mobile-client-server#configure-the-uid2-mobile-sdk)):
+
+``` javascript
+UID2Manager.shared.setIdentity(_ identity: UID2Identity)
+```
+
+Get the EUID token (advertising token) to pass to the Advertising SDK (for ad request or bidstream use):
+
+```js
+UID2Manager.shared.getAdvertisingToken()
+```
+
+## UID2Manager API
+
+This section includes the functions and variables that are part of the UID2Manager API.
+
+### Functions
+
+The following functions are available as part of the UID2Manager API:
+- [generateIdentity()](#generateidentity)
+- [setIdentity()](#setidentity)
+- [resetIdentity()](#resetidentity)
+- [refreshIdentity()](#refreshidentity)
+- [getAdvertisingToken()](#getadvertisingtoken)
+- [setAutomaticRefreshEnabled()](#setautomaticrefreshenabled)
+
+#### generateIdentity()
+
+Generate am EUID Identity using <Link href="../ref-info/glossary-uid#gl-dii">Directly identifying information (DII)</Link>. For details, see [Configure the EUID mobile SDK](../guides/integration-mobile-client-side.md#configure-the-uid2-mobile-sdk) in the *Client-Side Integration Guide for Mobile*.
+
+#### setIdentity()
+
+Sets an EUID Identity, created server-side, to be managed by the SDK. For details, see [Configure the EUID Mobile SDK](../guides/integration-mobile-client-server.md#configure-the-uid2-mobile-sdk) in the *Client-Server Integration Guide for Mobile*.
+
+#### resetIdentity()
+
+Resets or removes the EUID Identity currently being managed by the SDK.
+
+#### refreshIdentity()
+
+Manually refreshes the EUID Identity being managed by the SDK.
+
+#### getAdvertisingToken()
+
+If the current EUID Identity is valid, this function returns the EUID token (advertising token).
+
+#### setAutomaticRefreshEnabled()
+
+Toggle for automatic refresh functionality.
+
+### Variables
+
+The following variables are available as part of the UID2Manager API:
+
+- [identity](#identity)
+- [identityStatus](#identitystatus)
+
+#### identity
+
+The Identity variable stores and returns the current `UID2Identity` data object being managed by the SDK.
+
+#### identityStatus
+
+The identityStatus variable stores and returns the status of the current EUID Identity being managed by the SDK.
+

--- a/docs/sdks/sdk-ref-ios.md
+++ b/docs/sdks/sdk-ref-ios.md
@@ -15,12 +15,12 @@ You can use the SDK for iOS for the following:
 - Retrieving advertising tokens for <Link href="../ref-info/glossary-uid#gl-bidstream">bidstream</Link> use.
 - Automatically refreshing EUID tokens.
 
-The following iOS-related plugins, and associated documentation, are also available:
+<!-- The following iOS-related plugins, and associated documentation, are also available:
 
 | Purpose | Product/Documentation |
 | :--- | :--- |
-| To use the Google Mobile Ads (GMA) SDK to send <Link href="../ref-info/glossary-uid#gl-euid-token">EUID tokens</Link> as [secure signals](https://support.google.com/admob/answer/11556288) in ad requests from iOS/tvOS apps | [EUID GMA Plugin for iOS Integration Guide](../guides/mobile-plugin-gma-ios.md) |
-| To use the Google Interactive Media Ads SDK for iOS to send <Link href="../ref-info/glossary-uid#gl-euid-token">EUID tokens</Link> as [secure signals](https://support.google.com/admob/answer/11556288) in ad requests from iOS/tvOS apps | [EUID IMA Plugin for iOS Integration Guide](../guides/mobile-plugin-ima-ios.md) |
+| To use the Google Mobile Ads (GMA) SDK to send <Link href="../ref-info/glossary-uid#gl-euid-token">EUID tokens</Link> as [secure signals](https://support.google.com/admob/answer/11556288) in ad requests from iOS/tvOS apps | [EUID GMA Plugin for iOS Integration Guide]LINK REMOVED |
+| To use the Google Interactive Media Ads SDK for iOS to send <Link href="../ref-info/glossary-uid#gl-euid-token">EUID tokens</Link> as [secure signals](https://support.google.com/admob/answer/11556288) in ad requests from iOS/tvOS apps | [EUID IMA Plugin for iOS Integration Guide]LINK REMOVED | -->
 
 ## tvOS Support
 Although this page refers to SDK for iOS, this SDK also supports tvOS. For the required tvOS version, see [Minimum Requirements](#minimum-requirements).
@@ -103,15 +103,15 @@ pod 'UID2', '~> 1.2'
 
 ## Usage Guidelines
 
-The **UID2Manager** singleton is the primary developer API for the SDK for iOS. It is responsible for storing, refreshing, and retrieving the EUID Identity including the EUID token.
+The **EUIDManager** singleton is the primary developer API for the SDK for iOS. It is responsible for storing, refreshing, and retrieving the EUID Identity including the EUID token.
 
-For iOS, the `UID2Manager` is initialized automatically the first time it is accessed. You can configure it to support automatic or manual refresh capabilities.
+For iOS, the `EUIDManager` is initialized automatically the first time it is accessed. You can configure it to support automatic or manual refresh capabilities.
 
 There are two ways to establish an initial EUID Identity:
 
-1. Generate the EUID identity using DII&#8212;email (hashed or unhashed) or phone number (hashed or unhashed). For integration instructions, see [Client-Side Integration Guide for Mobile](../guides/integration-mobile-client-side.md).
+1. Generate the EUID identity using DII&#8212;email (hashed or unhashed). <!-- For integration instructions, see [Client-Side Integration Guide for Mobile]LINK REMOVED. -->
 
-2. Create an EUID identity from your server's back end and then pass it to the EUID SDK. For integration instructions, see [Client-Server Integration Guide for Mobile](../guides/integration-mobile-client-server).
+2. Create an EUID identity from your server's back end and then pass it to the EUID SDK. <!-- For integration instructions, see [Client-Server Integration Guide for Mobile]LINK REMOVED. -->
 
 The EUID Mobile SDKs can perform refreshes of EUID identities, after an Identity is established. This is because the refresh functionality relies on the refresh tokens that are part of the EUID Identity.
 
@@ -120,35 +120,35 @@ The EUID Mobile SDKs can perform refreshes of EUID identities, after an Identity
 
 The following code samples provide examples of performing specific activities relating to managing EUID with the SDK for iOS.
 
-Generate an initial EUID Identity (for instructions, see [Client-Side Integration Guide for Mobile](../guides/integration-mobile-client-side#configure-the-uid2-mobile-sdk)):
+Generate an initial EUID Identity<!--  (for instructions, see [Client-Side Integration Guide for Mobile]LINK REMOVED) -->:
 
 ```js
-UID2Manager.shared.generateIdentity(
+EUIDManager.shared.generateIdentity(
     _ identity: IdentityType,
     subscriptionID: String,
     serverPublicKey: String,
     appName: String? = nil
 )
 ```
-Set the Initial EUID Identity (for instructions, see [Client-Server Integration Guide for Mobile](../guides/integration-mobile-client-server#configure-the-uid2-mobile-sdk)):
+Set the Initial EUID Identity<!--  (for instructions, see [Client-Server Integration Guide for Mobile]LINK REMOVED) -->:
 
 ``` javascript
-UID2Manager.shared.setIdentity(_ identity: UID2Identity)
+EUIDManager.shared.setIdentity(_ identity: UID2Identity)
 ```
 
 Get the EUID token (advertising token) to pass to the Advertising SDK (for ad request or bidstream use):
 
 ```js
-UID2Manager.shared.getAdvertisingToken()
+EUIDManager.shared.getAdvertisingToken()
 ```
 
-## UID2Manager API
+## EUIDManager API
 
-This section includes the functions and variables that are part of the UID2Manager API.
+This section includes the functions and variables that are part of the EUIDManager API.
 
 ### Functions
 
-The following functions are available as part of the UID2Manager API:
+The following functions are available as part of the EUIDManager API:
 - [generateIdentity()](#generateidentity)
 - [setIdentity()](#setidentity)
 - [resetIdentity()](#resetidentity)
@@ -158,11 +158,11 @@ The following functions are available as part of the UID2Manager API:
 
 #### generateIdentity()
 
-Generate am EUID Identity using <Link href="../ref-info/glossary-uid#gl-dii">Directly identifying information (DII)</Link>. For details, see [Configure the EUID mobile SDK](../guides/integration-mobile-client-side.md#configure-the-uid2-mobile-sdk) in the *Client-Side Integration Guide for Mobile*.
+Generate am EUID Identity using <Link href="../ref-info/glossary-uid#gl-personal-data">personal data</Link>.<!--  For details, see [Configure the EUID mobile SDK]LINK REMOVED-#configure-the-uid2-mobile-sdk) in the *Client-Side Integration Guide for Mobile*. -->
 
 #### setIdentity()
 
-Sets an EUID Identity, created server-side, to be managed by the SDK. For details, see [Configure the EUID Mobile SDK](../guides/integration-mobile-client-server.md#configure-the-uid2-mobile-sdk) in the *Client-Server Integration Guide for Mobile*.
+Sets an EUID Identity, created server-side, to be managed by the SDK.<!--  For details, see [Configure the EUID Mobile SDK]LINK REMOVED in the *Client-Server Integration Guide for Mobile*. -->
 
 #### resetIdentity()
 
@@ -182,16 +182,18 @@ Toggle for automatic refresh functionality.
 
 ### Variables
 
-The following variables are available as part of the UID2Manager API:
+The following variables are available as part of the EUIDManager API:
 
 - [identity](#identity)
 - [identityStatus](#identitystatus)
 
 #### identity
 
-The Identity variable stores and returns the current `UID2Identity` data object being managed by the SDK.
+The `Identity` variable stores and returns the current `UID2Identity` data object being managed by the SDK.
+
+<!-- ^^^Note UID2Identity is for both UID2 and EUID.^^^ -->
 
 #### identityStatus
 
-The identityStatus variable stores and returns the status of the current EUID Identity being managed by the SDK.
+The `identityStatus` variable stores and returns the status of the current EUID Identity being managed by the SDK.
 

--- a/docs/sdks/sdk-ref-ios.md
+++ b/docs/sdks/sdk-ref-ios.md
@@ -98,7 +98,7 @@ In the XCode user interface, under Package Dependencies, add the following entry
 Add the following entry in your `Podfile`:
 
 ```
-pod 'UID2', '~> 1.2'
+pod 'UID2', '~> 1.7'
 ```
 
 ## Usage Guidelines

--- a/docs/sdks/summary-sdks.md
+++ b/docs/sdks/summary-sdks.md
@@ -25,6 +25,7 @@ The following table summarizes the functionality available with each SDK.
 |Python | Server | &#9989; | &#9989; | &#9989; | &#9989; | &#8212; |
 |C# / .NET | Server | &#9989; | &#9989; | &#8212; | &#8212; | &#8212; |
 |C++ | Server | &#9989; | &#9989; | &#8212; | &#8212; | &#8212; |
+|iOS | Client (Mobile)| &#8212; | &#8212; | &#9989;| &#9989; |&#8212; |
 
 <!-- &#9989; = Supported | &#10060; = Not Supported | &#8212; = Not Supported -->
 
@@ -39,4 +40,5 @@ The following SDK documentation is available for EUID integration. Documentation
 | [SDK for Python](sdk-ref-python.md) | An SDK for audiences using Python server-side:<ul><li>Helps publishers to generate or refresh EUID tokens from personal data ([POST&nbsp;/token/generate](../endpoints/post-token-generate)).</li><li>Helps DSPs to decrypt EUID tokens from bid requests ([Decrypt EUID Tokens for RTB Use](../guides/dsp-guide.md#decrypt-euid-tokens-for-rtb-use)).</li></ul> | Publishers<br/>DSPs |
 | [SDK for C# / .NET](sdk-ref-csharp-dotnet.md) | An SDK for audiences using .NET server-side:<ul><li>Helps DSPs to decrypt EUID tokens from bid requests.</li></ul> | DSPs<br/>Data Providers |
 | [SDK for C++](sdk-ref-cplusplus.md) | An SDK for audiences using C++ server-side:<ul><li>Helps DSPs to decrypt EUID tokens from bid requests.</li></ul> | DSPs<br/>Data Providers |
+| [SDK for iOS](sdk-ref-ios.md) | An SDK that facilitates the process of generating or establishing client identity using EUID and retrieving EUID tokens for publishers that need to support iOS apps. | Publishers |
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -144,16 +144,17 @@ const sidebars = {
       type: 'category',
       label: 'SDKs',
       link: {
-        type: 'generated-index',
+        type: 'doc',
+        id: 'sdks/summary-sdks',
       },
       collapsed: true,
       items: [
-        'sdks/summary-sdks',
         'sdks/sdk-ref-javascript',
         'sdks/sdk-ref-java',
         'sdks/sdk-ref-python',
         'sdks/sdk-ref-csharp-dotnet',
         'sdks/sdk-ref-cplusplus',
+        'sdks/sdk-ref-ios',
       ],
     },
 


### PR DESCRIPTION
- Add iOS SDK file. Some mods needed still.
- Add lead-ins from Publisher Overview and SDK Summary
- Update sidebar.
Note updates are needed to code samples, references to code elements, URLs, all of which have UID2 in them.