### PR TITLE
EUID add glossary def for Unix time

### DIFF
--- a/docs/endpoints/post-optout-status.md
+++ b/docs/endpoints/post-optout-status.md
@@ -110,7 +110,7 @@ The response body includes the following properties.
 | Property | Format | Description |
 | :--- | :--- | :--- |
 | `advertising_id` | string | The <Link href="../ref-info/glossary-uid#gl-advertising-id">advertising ID</Link> (raw EUID). |
-| `opted_out_since` | number | The UNIX timestamp (in milliseconds) that indicates when the raw EUID was opted out. |
+| `opted_out_since` | number | The <a href="../ref-info/glossary-uid#gl-unix-time">Unix</a> timestamp (in milliseconds) that indicates when the raw EUID was opted out. |
 
 ### Response Status Codes
 

--- a/docs/endpoints/post-token-generate.md
+++ b/docs/endpoints/post-token-generate.md
@@ -122,9 +122,9 @@ Here is an example response when the user has opted out.
 | :--- | :--- | :--- |
 | `advertising_token` | string | An encrypted advertising (EUID) token for the user. |
 | `refresh_token` | string | An encrypted token that can be exchanged with the EUID Service for the latest set of identity tokens. |
-| `identity_expires` | number | The UNIX timestamp (in milliseconds) that indicates when the advertising token expires. |
-| `refresh_from` | number | The UNIX timestamp (in milliseconds) that indicates when the SDK for JavaScript (see [SDK for JavaScript Reference Guide](../sdks/sdk-ref-javascript.md)) will start refreshing the EUID token.<br/>TIP: If you are not using the SDK, consider refreshing the EUID token from this timestamp, too. |
-| `refresh_expires` | number | The UNIX timestamp (in milliseconds) that indicates when the refresh token expires. |
+| `identity_expires` | number | The <a href="../ref-info/glossary-uid#gl-unix-time">Unix</a> timestamp (in milliseconds) that indicates when the advertising token expires. |
+| `refresh_from` | number | The Unix timestamp (in milliseconds) that indicates when the SDK for JavaScript (see [SDK for JavaScript Reference Guide](../sdks/sdk-ref-javascript.md)) will start refreshing the EUID token.<br/>TIP: If you are not using the SDK, consider refreshing the EUID token from this timestamp, too. |
+| `refresh_expires` | number | The Unix timestamp (in milliseconds) that indicates when the refresh token expires. |
 | `refresh_response_key` | string | A key to be used in a [POST&nbsp;/token/refresh](post-token-refresh.md) request for response decryption. |
 
 ### Response Status Codes

--- a/docs/endpoints/post-token-refresh.md
+++ b/docs/endpoints/post-token-refresh.md
@@ -96,9 +96,9 @@ The response body includes the properties shown in the following table.
 | :--- | :--- | :--- |
 | `advertising_token` | string | The <Link href="../ref-info/glossary-uid#gl-euid-token">EUID token</Link> (also known as advertising token) for the user. |
 | `refresh_token` | string | An encrypted token that can be exchanged with the EUID Service for the latest set of identity tokens. |
-| `identity_expires` | number | The UNIX timestamp (in milliseconds) that indicates when the EUID token expires. |
-| `refresh_from` | number | The UNIX timestamp (in milliseconds) that indicates when the SDK for JavaScript (see [SDK for JavaScript Reference Guide](../sdks/sdk-ref-javascript.md)) will start refreshing the EUID token, if the SDK is in use.<br/>TIP: If you are not using the SDK, consider refreshing the EUID token from this timestamp, too. |
-| `refresh_expires` | number | The UNIX timestamp (in milliseconds) that indicates when the refresh token expires. |
+| `identity_expires` | number | The <a href="../ref-info/glossary-uid#gl-unix-time">Unix</a> timestamp (in milliseconds) that indicates when the EUID token expires. |
+| `refresh_from` | number | The Unix timestamp (in milliseconds) that indicates when the SDK for JavaScript (see [SDK for JavaScript Reference Guide](../sdks/sdk-ref-javascript.md)) will start refreshing the EUID token, if the SDK is in use.<br/>TIP: If you are not using the SDK, consider refreshing the EUID token from this timestamp, too. |
+| `refresh_expires` | number | The Unix timestamp (in milliseconds) that indicates when the refresh token expires. |
 | `refresh_response_key` | string | A key to be used in a new [POST&nbsp;/token/refresh](post-token-refresh.md) request for response decryption. |
 
 ### Response Status Codes

--- a/docs/getting-started/gs-encryption-decryption.md
+++ b/docs/getting-started/gs-encryption-decryption.md
@@ -57,7 +57,7 @@ The following table describes the field layout for request encryption code.
 
 | Offset (Bytes) | Size (Bytes) | Description |
 | :--- | :--- | :--- |
-| 0 | 8 | The UNIX timestamp (in milliseconds). Must be int64 big endian. |
+| 0 | 8 | The <a href="../ref-info/glossary-uid#gl-unix-time">Unix</a> timestamp (in milliseconds). Must be int64 big endian. |
 | 8 | 8 | Nonce: Random 64 bits of data used to help protect against replay attacks. The corresponding [Unencrypted Response Data Envelope](#unencrypted-response-data-envelope) should contain the same nonce value for the response to be considered valid. |
 | 16 | N | Payload, which is a request JSON document serialized in UTF-8 encoding. |
 
@@ -96,7 +96,7 @@ The following table describes the field layout for response decryption code.
 
 | Offset (Bytes) | Size (Bytes) | Description |
 | :--- | :--- | :--- |
-| 0 | 8 | The UNIX timestamp (in milliseconds). Must be int64 big endian. |
+| 0 | 8 | The Unix timestamp (in milliseconds). Must be int64 big endian. |
 | 8 | 8 | Nonce. For the response to be considered valid, this should match the nonce in the [unencrypted request data envelope](#unencrypted-request-data-envelope). |
 | 16 | N | Payload, which is a response JSON document serialized in UTF-8 encoding. |
 

--- a/docs/guides/integration-publisher-server-side.md
+++ b/docs/guides/integration-publisher-server-side.md
@@ -82,7 +82,7 @@ For an example of what an EUID token might look like in the bidstream, when it's
 
 ### Refresh an EUID Token
 
-Use the `POST&nbsp;/token/refresh` endpoint to make sure you always have a valid and up-to-date EUID token. The EUID token must be refreshed to sync with the EUID rotation. In addition, the token refresh process checks the user's opt-out status, and if the user has opted out, no new token is sent. This ends the token refresh chain, and you must not use that EUID token again.
+Use the `POST /token/refresh` endpoint to make sure you always have a valid and up-to-date EUID token. The EUID token must be refreshed to sync with the EUID rotation. In addition, the token refresh process checks the user's opt-out status, and if the user has opted out, no new token is sent. This ends the token refresh chain, and you must not use that EUID token again.
 
 | Step | Endpoint | Description |
 | :--- | :--- | :--- |

--- a/docs/ref-info/glossary-uid.md
+++ b/docs/ref-info/glossary-uid.md
@@ -420,6 +420,10 @@ import Link from '@docusaurus/Link';
 <dd>There are many similarities between UID2 and EUID, but they are completely separate, and their tokens are not interchangeable.</dd>
 <dd>For details, see <a href="https://unifiedid.com/docs/intro">Unified ID 2.0 Overview</a>.</dd>
 
+<dt><MdxJumpAnchor id="gl-unix-time"><a href="#gl-unix-time">Unix time</a></MdxJumpAnchor></dt>
+<dd>Unix time, also called Epoch time, is defined as the number of seconds since 00:00:00 <a href="#gl-utc">UTC</a> on Thursday, 1 January 1970. Unix time is used in some EUID response messages, expressed in milliseconds: for example, in the response to the `POST /token/refresh` endpoint (see <a href="../endpoints/post-token-refresh#successful-response-with-tokens">Successful Response With Tokens</a>).</dd>
+<dd>Example: 1 January 2024, 9:00:00 AM GMT, expressed in Unix time, is `1704067200`. In milliseconds it is: `1704067200000`.</dd>
+
 <dt><MdxJumpAnchor id="gl-utc"><a href="#gl-utc">UTC</a></MdxJumpAnchor></dt>
 <dd>UTC is an abbreviation for Coordinated Universal Time, also called Zulu time, which is the primary time standard in general use. UTC essentially equates to Greenwich Mean Time (GMT), but is more scientifically precise.</dd>
 

--- a/docs/ref-info/ref-tokens.md
+++ b/docs/ref-info/ref-tokens.md
@@ -49,7 +49,7 @@ Here are some key points about refresh tokens:
 
 The recommended refresh interval is hourly.
 
-To determine when to refresh, you can use the timestamp of the `refresh_from` field in the response to the [POST&nbsp;/token/generate](../endpoints/post-token-generate.md) endpoint (see [Successful Response](../endpoints/post-token-generate.md#successful-response)) or [POST&nbsp;/token/refresh](../endpoints/post-token-refresh.md) endpoint (see [Successful Response With Tokens](../endpoints/post-token-refresh.md#successful-response-with-tokens)). The value of this field is a timestamp in UNIX time, expressed in milliseconds.
+To determine when to refresh, you can use the timestamp of the `refresh_from` field in the response to the [POST&nbsp;/token/generate](../endpoints/post-token-generate.md) endpoint (see [Successful Response](../endpoints/post-token-generate.md#successful-response)) or [POST&nbsp;/token/refresh](../endpoints/post-token-refresh.md) endpoint (see [Successful Response With Tokens](../endpoints/post-token-refresh.md#successful-response-with-tokens)). The value of this field is a timestamp in <a href="../ref-info/glossary-uid#gl-unix-time">Unix</a> time, expressed in milliseconds.
 
 ### Managing Token Refresh with an SDK
 


### PR DESCRIPTION
- add glossary def for Unix time.
- Change instances UNIX > Unix per research.