### PR TITLE
Add missing optout_check

### DIFF
--- a/docs/getting-started/gs-encryption-decryption.md
+++ b/docs/getting-started/gs-encryption-decryption.md
@@ -227,7 +227,7 @@ Usage:
    echo '<json>' | python3 uid2_request.py <url> <api_key> <client_secret>
 
 Example:
-   echo '{"email": "test@example.com"}' | python3 uid2_request.py https://prod.euid.eu/v2/token/generate PRODGwJ0hP19QU4hmpB64Y3fV2dAed8t/mupw3sjN5jNRFzg= wJ0hP19QU4hmpB64Y3fV2dAed8t/mupw3sjN5jNRFzg=
+   echo '{"email": "test@example.com", "optout_check": 1}' | python3 uid2_request.py https://prod.euid.eu/v2/token/generate PRODGwJ0hP19QU4hmpB64Y3fV2dAed8t/mupw3sjN5jNRFzg= wJ0hP19QU4hmpB64Y3fV2dAed8t/mupw3sjN5jNRFzg=
    
 
 Refresh Token Usage:
@@ -355,7 +355,7 @@ public class Uid2Request {
       +             "java -jar Uid2Request-jar-with-dependencies.jar <url> <api_key> <client_secret>" + "\n\n"
       
       +       "Example:" + "\n   "  
-      +             "echo '{\"email\": \"test@example.com\"}' | java -jar Uid2Request-jar-with-dependencies.jar https://prod.euid.eu/v2/token/generate PRODGwJ0hP19QU4hmpB64Y3fV2dAed8t/mupw3sjN5jNRFzg= wJ0hP19QU4hmpB64Y3fV2dAed8t/mupw3sjN5jNRFzg=" + "\n\n\n"
+      +             "echo '{\"email\": \"test@example.com\",\"optout_check\": 1}' | java -jar Uid2Request-jar-with-dependencies.jar https://prod.euid.eu/v2/token/generate PRODGwJ0hP19QU4hmpB64Y3fV2dAed8t/mupw3sjN5jNRFzg= wJ0hP19QU4hmpB64Y3fV2dAed8t/mupw3sjN5jNRFzg=" + "\n\n\n"
       
       +       "Refresh Token Usage:" + "\n   "
       +             "java -jar Uid2Request-jar-with-dependencies.jar <url> --refresh-token <refresh_token> <refresh_response_key>"  + "\n\n"
@@ -465,7 +465,7 @@ Usage:
    echo '<json>' | .\uid2_request <url> <api_key> <client_secret>
 
 Example:
-   echo '{"email": "test@example.com"}' | .\uid2_request https://prod.euid.eu/v2/token/generate UID2-C-L-999-fCXrMM.fsR3mDqAXELtWWMS+xG1s7RdgRTMqdOH2qaAo= wJ0hP19QU4hmpB64Y3fV2dAed8t/mupw3sjN5jNRFzg=
+   echo '{"email": "test@example.com", "optout_check": 1}' | .\uid2_request https://prod.euid.eu/v2/token/generate UID2-C-L-999-fCXrMM.fsR3mDqAXELtWWMS+xG1s7RdgRTMqdOH2qaAo= wJ0hP19QU4hmpB64Y3fV2dAed8t/mupw3sjN5jNRFzg=
    
 
 Refresh Token Usage:

--- a/docs/getting-started/gs-encryption-decryption.md
+++ b/docs/getting-started/gs-encryption-decryption.md
@@ -113,7 +113,7 @@ This section includes encryption and decryption code examples in different progr
 For the [POST&nbsp;/token/refresh](../endpoints/post-token-refresh.md) endpoint, the code takes the values for `refresh_token` and `refresh_response_key` that were obtained from a prior call to [POST&nbsp;/token/generate](../endpoints/post-token-generate.md) or [POST&nbsp;/token/refresh](../endpoints/post-token-refresh.md).
 
 :::note
-For Windows, if you're using Windows Command Prompt instead of PowerShell, you must also remove the single quotes surrounding the JSON. For example, use `echo {"email": "test@example.com"}`.
+For Windows, if you're using Windows Command Prompt instead of PowerShell, you must also remove the single quotes surrounding the JSON. For example, use `echo {"email": "test@example.com", "optout_check": 1}`.
 :::
 
 ### Prerequisites and Notes


### PR DESCRIPTION
Add the required optout_check 

https://unifiedid.com/docs/getting-started/gs-encryption-decryption

The code examples there for calling v2/token/generate doesn't have "optout_check:1" which we required for all new participants to add into the request since late last year.

 

We should specify like this:

echo '{"email": "sunny@example.com","optout_check":1}' | python3.10 uid2_request.py https://prod.uidapi.com/v2/token/generate .....

