### PR TITLE
fix: 💄  Color mode switching between pages

### DIFF
--- a/src/utils/useForcedDarkTheme.ts
+++ b/src/utils/useForcedDarkTheme.ts
@@ -1,11 +1,12 @@
 import * as React from "react";
-import { useColorMode } from "@docusaurus/theme-common";
+import { useColorMode, ColorMode } from "@docusaurus/theme-common";
 
 export function useForcedDarkTheme() {
   const { setColorMode, colorMode } = useColorMode();
   //quick fix for updating color mode on page load breaking after theme upgrade
   React.useEffect(() => {
-    const originalTheme = colorMode;
+    const originalTheme =
+      (localStorage.getItem("theme") as ColorMode) ?? colorMode;
 
     //@ts-expect-error - The second parameter exists, it's just not on the type :(
     setColorMode("dark", { persist: false });


### PR DESCRIPTION
### PR Details

This PR fixes the issue when navigating between docs and marketing pages, the color mode switches. This is now being fixed by using the session variable to set the mode and not constantly change
