### PR TITLE
ibg-CORPWEB-3437-404-page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16522,9 +16522,10 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
       }

--- a/src/theme/NotFound/Content/index.tsx
+++ b/src/theme/NotFound/Content/index.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import clsx from "clsx";
-import Translate from "@docusaurus/Translate";
 import type { Props } from "@theme/NotFound/Content";
 import Heading from "@theme/Heading";
+import Link from "@docusaurus/Link";
 
 export default function NotFoundContent({ className }: Props): JSX.Element {
   return (
@@ -10,30 +10,25 @@ export default function NotFoundContent({ className }: Props): JSX.Element {
       <div className="row">
         <div className="col col--6 col--offset-3">
           <Heading as="h1" className="hero__title">
-            <Translate
-              id="theme.NotFound.title"
-              description="The title of the 404 page"
-            >
-              Page Not Found
-            </Translate>
+            Page Not Found
           </Heading>
           <p>
-            <Translate
-              id="theme.NotFound.p1"
-              description="The first paragraph of the 404 page"
-            >
-              We could not find what you were looking for.
-            </Translate>
+            We couldn't find the page you were looking for. The page might have
+            been moved, or there was an error in the link.
           </p>
-          <p>
-            <Translate
-              id="theme.NotFound.p2"
-              description="The 2nd paragraph of the 404 page"
-            >
-              Please contact the owner of the site that linked you to the
-              original URL and let them know their link is broken.
-            </Translate>
-          </p>
+          <p>Here are some things you can do:</p>
+          <ul>
+            <li>Go back and retry the link.</li>
+            <li>
+              Search for the document by its title or keywords from any UID2
+              page.
+            </li>
+            <li>
+              <Link to="/docs/intro">
+                Visit the UID2 documentation home page
+              </Link>
+            </li>
+          </ul>
         </div>
       </div>
     </main>

--- a/src/theme/NotFound/Content/index.tsx
+++ b/src/theme/NotFound/Content/index.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import clsx from "clsx";
+import Translate from "@docusaurus/Translate";
+import type { Props } from "@theme/NotFound/Content";
+import Heading from "@theme/Heading";
+
+export default function NotFoundContent({ className }: Props): JSX.Element {
+  return (
+    <main className={clsx("container margin-vert--xl", className)}>
+      <div className="row">
+        <div className="col col--6 col--offset-3">
+          <Heading as="h1" className="hero__title">
+            <Translate
+              id="theme.NotFound.title"
+              description="The title of the 404 page"
+            >
+              Page Not Found
+            </Translate>
+          </Heading>
+          <p>
+            <Translate
+              id="theme.NotFound.p1"
+              description="The first paragraph of the 404 page"
+            >
+              We could not find what you were looking for.
+            </Translate>
+          </p>
+          <p>
+            <Translate
+              id="theme.NotFound.p2"
+              description="The 2nd paragraph of the 404 page"
+            >
+              Please contact the owner of the site that linked you to the
+              original URL and let them know their link is broken.
+            </Translate>
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/theme/NotFound/Content/index.tsx
+++ b/src/theme/NotFound/Content/index.tsx
@@ -20,12 +20,12 @@ export default function NotFoundContent({ className }: Props): JSX.Element {
           <ul>
             <li>Go back and retry the link.</li>
             <li>
-              Search for the document by its title or keywords from any UID2
+              Search for the document by its title or keywords from any EUID
               page.
             </li>
             <li>
               <Link to="/docs/intro">
-                Visit the UID2 documentation home page
+                Visit the EUID documentation home page.
               </Link>
             </li>
           </ul>

--- a/src/theme/NotFound/index.tsx
+++ b/src/theme/NotFound/index.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { translate } from "@docusaurus/Translate";
+import { PageMetadata } from "@docusaurus/theme-common";
+import Layout from "@theme/Layout";
+import NotFoundContent from "@theme/NotFound/Content";
+
+export default function Index(): JSX.Element {
+  const title = translate({
+    id: "theme.NotFound.title",
+    message: "Page Not Found",
+  });
+  return (
+    <>
+      <PageMetadata title={title} />
+      <Layout>
+        <NotFoundContent />
+      </Layout>
+    </>
+  );
+}

--- a/src/theme/NotFound/index.tsx
+++ b/src/theme/NotFound/index.tsx
@@ -9,6 +9,7 @@ export default function Index(): JSX.Element {
     id: "theme.NotFound.title",
     message: "Page Not Found",
   });
+
   return (
     <>
       <PageMetadata title={title} />


### PR DESCRIPTION
## Changes

- I ran the command to eject the `NotFound` theme component, allowing customization to 404 pages.
  - Command run: `npm run swizzle @docusaurus/theme-classic NotFound`
- Changes to the file `src/theme/NotFound/Content/index.tsx` will be shown on the 404 page.