### PR TITLE
Private Operator docs, remove 2024 Q1 version, EUID

### DIFF
--- a/docs/guides/operator-guide-aws-marketplace.md
+++ b/docs/guides/operator-guide-aws-marketplace.md
@@ -165,7 +165,6 @@ The latest ZIP file is linked in the Release Notes column in the following table
 
 | Release | Version | Date | Release Notes | Version |
 | ------- | ------ | ------ | ------ | ------ |
-| Q1 2024 | 5.26.19 | February 13, 2024 | [v5.26.19-56899dc0d7](https://github.com/IABTechLab/uid2-operator/releases/tag/v5.26.19-56899dc0d7) | 5.26.19-56899dc0d7 |
 | Q2 2024 | 5.37.12 | June 12, 2024 | [v5.37.12](https://github.com/IABTechLab/uid2-operator/releases/tag/v5.37.12) | 5.37.12 |
 | Q3 2024 | 5.38.104 | September 12, 2024 | [v5.38.104](https://github.com/IABTechLab/uid2-operator/releases/tag/v5.38.104) | 5.38.104 |
 | Q3 2024 Out-of-band | 5.41.0 | October 29, 2024 | [v5.41.0](https://github.com/IABTechLab/uid2-operator/releases/tag/v5.41.0) | 5.41.0 |


### PR DESCRIPTION
Private Operator docs, remove 2024 Q1 version, EUID