### PR TITLE
publisher docs add private operator info

### DIFF
--- a/docs/guides/integration-ctv-guide.md
+++ b/docs/guides/integration-ctv-guide.md
@@ -9,6 +9,7 @@ sidebar_position: 04
 
 import Link from '@docusaurus/Link';
 import IntegratingWithSSO from '../snippets/_integrating-with-sso.mdx';
+import PrivateOperatorOption from '../snippets/_private-operator-option.mdx'
 
 # CTV Integration Guide
 
@@ -27,13 +28,19 @@ To determine how you'll implement these steps, choose from the [CTV Integration 
 
 <IntegratingWithSSO />
 
+## Private Operator Option
+
+<PrivateOperatorOption/>
+
 ## CTV Integration Options
 
-You can decide on the integration option that's best for you based on where you want to generate and refresh the EUID token. There are three options, as follows:
+You can decide on the integration option that's best for you based on where you want to generate and refresh the EUID token. There are three options, as shown in the following table.
 
-- [Client-Side Integration](#client-side-integration-for-ctv-apps) (the token is generated and refreshed on the client side)
-- [Server-Side Integration](#server-side-integration-for-ctv-apps) (the token is generated and refreshed on the server side)
-- [Client-Server Integration](#client-server-integration-for-ctv-apps) (the token is generated on the server side and refreshed on the client side)
+| Option | Details |
+| :--- | :--- |
+| [Client-Side Integration](#client-side-integration-for-ctv-apps) | The token is generated and refreshed on the client side. |
+| [Server-Side Integration](#server-side-integration-for-ctv-apps) | The token is generated and refreshed on the server side. |
+| [Client-Server Integration](#client-server-integration-for-ctv-apps) | The token is generated on the server side and refreshed on the client side. |
 
 ## Client-Side Integration for CTV Apps
 

--- a/docs/guides/integration-options-private-operator.md
+++ b/docs/guides/integration-options-private-operator.md
@@ -8,7 +8,7 @@ import Link from '@docusaurus/Link';
 
 # EUID Private Operator Integration Overview
 
-EUID participants that host their own <Link href="../ref-info/glossary-uid#gl-private-operator">Private Operator</Link> send their own first-party <Link href="../ref-info/glossary-uid#gl-personal-data">personal data</Link> to their own, local EUID <Link href="../ref-info/glossary-uid#gl-operator">Operator</Link> service, running in a private environment.
+EUID participants that host their own <Link href="../ref-info/glossary-uid#gl-private-operator">Private Operator</Link> send their own first-party <Link href="../ref-info/glossary-uid#gl-personal-data">personal data</Link> to their own local EUID <Link href="../ref-info/glossary-uid#gl-operator">Operator</Link> service, running in a private environment.
 
 A Private Operator runs in an <Link href="../ref-info/glossary-uid#gl-enclave">enclave</Link>&#8212;a virtual machine with additional security features to prevent unauthorized access, so that unauthorized individuals cannot download any configuration information or data from the virtual machine.
 

--- a/docs/guides/integration-options-publisher-all.md
+++ b/docs/guides/integration-options-publisher-all.md
@@ -1,0 +1,14 @@
+---
+title: Publisher Integration Resources
+description: Overview of the resources available for publishers integrating with EUID.
+hide_table_of_contents: false
+sidebar_position: 02
+displayed_sidebar: sidebarPublishers
+---
+
+import Link from '@docusaurus/Link';
+import PublisherImplementationResources from '../snippets/_publisher-implementation-resources.mdx';
+
+# Publisher Integration Resources
+
+<PublisherImplementationResources/>

--- a/docs/guides/integration-options-publisher-web.md
+++ b/docs/guides/integration-options-publisher-web.md
@@ -43,6 +43,8 @@ To accomplish all steps, you can combine solutions. For example, you could use t
 
 <!-- &#9989; = Supported | &#8212; = Not Supported -->
 
+## Publisher Web Options Workflow
+
 To choose your implementation and get started, follow these steps:
 
 1. Review the summary of options to generate an EUID token:

--- a/docs/overviews/overview-publishers.md
+++ b/docs/overviews/overview-publishers.md
@@ -16,6 +16,8 @@ displayed_sidebar: sidebarPublishers
 
 import Link from '@docusaurus/Link';
 import IntegratingWithSSO from '../snippets/_integrating-with-sso.mdx';
+import PrivateOperatorOption from '../snippets/_private-operator-option.mdx';
+import PublisherImplementationResources from '../snippets/_publisher-implementation-resources.mdx';
 
 As a publisher, you can benefit from the cross-device presence of European Unified ID (EUID) and take advantage of a consistent identity fabric on all your inventory.
 
@@ -71,6 +73,10 @@ The following steps provide a high-level outline of the workflow intended for or
 
 <IntegratingWithSSO />
 
+## Private Operator Option
+
+<PrivateOperatorOption/>
+
 ## Getting Started
 
 To get started, follow these steps:
@@ -97,76 +103,7 @@ To get started, follow these steps:
 
 ## Implementation Resources
 
-The following resources are available for publishers to implement EUID:
-
-- [Web Integrations](#web-integrations)
-- [Mobile Integrations](#mobile-integrations)
-- [CTV Integrations](#ctv-integrations)
-- [Prebid Integrations](#prebid-integrations)
-- [Google Ad Manager Integrations](#google-ad-manager-integrations)
-
-### Web Integrations
-
-The following resources are available for publisher web integrations.
-
-:::tip
-For a detailed summary of web integration options, see [Web Integration Overview](../guides/integration-options-publisher-web.md).
-:::
-
-| Integration Type| Documentation | Content Description |
-| :--- | :--- | :--- |
-| Prebid (Overview) | [EUID Integration Overview for Prebid](../guides/integration-prebid.md) | An overview of options for publishers who want to integrate with EUID and generate <Link href="../ref-info/glossary-uid#gl-euid-token">EUID tokens</Link> (advertising tokens) to be passed by Prebid.js or the Prebid Mobile SDK in the RTB bidstream. |
-| Prebid.js Client-Side Integration | [EUID Client-Side Integration Guide for Prebid.js](../guides/integration-prebid-client-side.md) | A guide for publishers who want to request EUID tokens client-side, which is the easiest implementation approach, and choose to have Prebid.js manage the following: <ul><li>Token generation and <a href="../ref-info/glossary-uid#gl-token-refresh">token refresh</a>.</li><li>Passing the tokens into the RTB bidstream.</li></ul> |
-| Prebid.js Client-Server Integration | [EUID Client-Server Integration Guide for Prebid.js](../guides/integration-prebid-client-server.md) | A guide for publishers who want to integrate with EUID and generate EUID tokens to be passed by Prebid.js in the RTB bidstream, but want to generate tokens server-side: for example, publishers who are using a <Link href="../ref-info/glossary-uid#gl-private-operator">Private Operator</Link>. |
-| JavaScript (Overview) | [EUID Integration Overview for JavaScript](../guides/integration-javascript.md) | An overview of options for publishers who want to integrate with EUID using the JavaScript SDK. |
-| JavaScript Client-Side Integration | [Client-Side Integration Guide for JavaScript](../guides/integration-javascript-client-side.md) | A guide for publishers who want to integrate with EUID using only client-side JavaScript changes, which is the easiest implementation approach.<br/>The SDK for JavaScript manages token generation and token refresh automatically. |
-| JavaScript Client-Server Integration | [Client-Server Integration Guide for JavaScript](../guides/integration-javascript-client-server.md) | A publisher guide covering standard web integration scenarios that use the SDK for JavaScript and require tokens to be generated on the server side and passed to the publisher web pages. |
-| Server-Side Integration | [Publisher Integration Guide, Server-Side](../guides/integration-publisher-server-side.md) | A guide for publishers who do not use the [SDK for JavaScript](../sdks/sdk-ref-javascript.md). |
-| Publisher/SSP Integration with GAM | [Google Ad Manager Secure Signals Integration Guide](../guides/integration-google-ss.md) | A guide covering the additional steps needed for publishers using EUID with the Google Ad Manager Secure Signals feature (previously known as Encrypted Signals for Publishers, ESP). |
-
-### Mobile Integrations
-
-The following resources are available for publisher integrations supporting Android or iOS devices.
-
-| Integration Type| Documentation | Content Description |
-| :--- | :--- | :--- |
-| Android/iOS (Overview) | [Mobile Integration Overview for Android and iOS](../guides/integration-mobile-overview.md) | An overview of options for mobile app publishers who want to integrate with EUID using the SDK for Android or the SDK for iOS. |
-| Android/iOS, Client-Side Integration | [Client-Side Integration Guide for Mobile](../guides/integration-mobile-client-side.md) | An integration guide for mobile app publishers who want to integrate with EUID with changes only within the mobile app (no server-side changes). |
-| Android/iOS, Client-Server Integration | [Client-Server Integration Guide for Mobile](../guides/integration-mobile-client-server.md) | An integration guide for mobile app publishers who want to integrate with EUID by doing the following:<ol><li>Generating EUID tokens server-side via either a Public or Private Operator.</li><li>Passing the resulting <Link href="../ref-info/glossary-uid#gl-identity">identities</Link> to a mobile app for passing into the bidstream.</li></ol> |
-| Android/iOS, Server-Side Integration | [Server-Side Integration Guide for Mobile](../guides/integration-mobile-server-side.md) | An integration guide for mobile app publishers who want to manage the EUID token entirely on the server side. |
-| Android | [SDK for Android Reference Guide](../sdks/sdk-ref-android.md) |An SDK that facilitates the process of generating or establishing client identity using EUID and retrieving EUID tokens for publishers that need to support Android apps. |
-| iOS | [SDK for iOS Reference Guide](../sdks/sdk-ref-ios.md) | An SDK that facilitates the process of generating or establishing client identity using EUID and retrieving EUID tokens for publishers that need to support iOS apps. |
-
-### CTV Integrations
-
-The following resources are available for publisher integrations supporting CTV.
-
-| Integration Type| Documentation | Content Description |
-| :--- | :--- | :--- |
-| CTV | [CTV Integration Guide](../guides/integration-ctv-guide.md) | A summary of CTV integration options, with links to additional information and instructions. |
-
-### Prebid Integrations
-
-The following resources are available for publishers integrating with Prebid.
-
-| Integration Type| Documentation | Content Description |
-| :--- | :--- | :--- |
-| Prebid (Overview) | [EUID Integration Overview for Prebid](../guides/integration-prebid.md) | An overview of options for publishers who want to integrate with EUID and generate <Link href="../ref-info/glossary-uid#gl-euid-token">EUID tokens</Link> (advertising tokens) to be passed by Prebid.js or the Prebid Mobile SDK in the RTB bidstream. |
-| Prebid.js Client-Side Integration | [EUID Client-Side Integration Guide for Prebid.js](../guides/integration-prebid-client-side.md) | A guide for publishers who want to request EUID tokens client-side, which is the easiest implementation approach, and choose to have Prebid.js manage the following: <ul><li>Token generation and <a href="../ref-info/glossary-uid#gl-token-refresh">token refresh</a>.</li><li>Passing the tokens into the RTB bidstream.</li></ul> |
-| Prebid.js Client-Server Integration | [EUID Client-Server Integration Guide for Prebid.js](../guides/integration-prebid-client-server.md) | A guide for publishers who want to integrate with EUID and generate EUID tokens to be passed by Prebid.js in the RTB bidstream, but want to generate tokens server-side: for example, publishers who are using a Private Operator. |
-| Prebid.js on Mobile | [EUID Mobile Integration for Prebid.js](../guides/integration-prebid-mobile-summary.md) | A summary of information resources for EUID integration with Prebid.js on mobile devices. |
-
-### Google Ad Manager Integrations
-
-The following resources are available for publishers integrating with Google Ad Manager.
-
-| Integration Type| Documentation | Content Description |
-| :--- | :--- | :--- |
-| Publisher/SSP Integration with GAM | [Google Ad Manager Secure Signals Integration Guide](../guides/integration-google-ss.md) | A guide covering the additional steps needed for publishers using EUID with the Google Ad Manager Secure Signals feature (previously known as Encrypted Signals for Publishers, ESP). |
-| GMA for Android | [EUID GMA Plugin for Android Integration Guide](../guides/mobile-plugin-gma-android.md) | A guide that enables publishers using the Google Mobile Ads (GMA) SDK to include EUID tokens in ad requests from their Android apps. |
-| GMA for iOS | [EUID GMA Plugin for iOS Integration Guide](../guides/mobile-plugin-gma-ios.md) | A guide that enables publishers using the Google Mobile Ads (GMA) SDK to include EUID tokens in ad requests from their iOS apps. |
-| IMA for Android | [EUID IMA Plugin for Android Integration Guide](../guides/mobile-plugin-ima-android.md) | A guide that enables publishers using the Google Interactive Media Ads (IMA) SDK to include EUID tokens in ad requests from their Android apps. |
-| IMA for iOS | [EUID IMA Plugin for iOS Integration Guide](../guides/mobile-plugin-ima-ios.md) | A guide that enables publishers using the Google Interactive Media Ads (IMA) SDK to include EUID tokens in ad requests from their iOS apps. |
+<PublisherImplementationResources/>
 
 ## FAQs for Publishers
 

--- a/docs/snippets/_private-operator-option.mdx
+++ b/docs/snippets/_private-operator-option.mdx
@@ -1,0 +1,12 @@
+import Link from '@docusaurus/Link';
+
+If you're a publisher and want to keep your first-party data within your corporate network, you might choose to deploy a <Link href="../ref-info/glossary-uid#gl-private-operator">Private Operator</Link>. In this scenario, you choose to host a private instance exclusively for your own use.
+
+For additional information, review these resources:
+
+- [The EUID Operator](../ref-info/ref-operators-public-private.md)
+- [EUID Private Operator Integration Overview](../guides/integration-options-private-operator.md)
+
+:::note
+The EUID Private Operator solutions do not support client-side generation of the EUID token. If you want a client-side implementation, you must use a Public Operator solution.
+:::

--- a/docs/snippets/_publisher-implementation-resources.mdx
+++ b/docs/snippets/_publisher-implementation-resources.mdx
@@ -1,0 +1,72 @@
+import Link from '@docusaurus/Link';
+
+The following resources are available for publishers to implement EUID:
+
+- [Web Integrations](#web-integrations)
+- [Mobile Integrations](#mobile-integrations)
+- [CTV Integrations](#ctv-integrations)
+- [Prebid Integrations](#prebid-integrations)
+- [Google Ad Manager Integrations](#google-ad-manager-integrations)
+
+### Web Integrations
+
+The following resources are available for publisher web integrations.
+
+:::tip
+For a detailed summary of web integration options, see [Web Integration Overview](../guides/integration-options-publisher-web.md).
+:::
+
+| Integration Type| Documentation | Content Description |
+| :--- | :--- | :--- |
+| Prebid (Overview) | [EUID Integration Overview for Prebid](../guides/integration-prebid.md) | An overview of options for publishers who want to integrate with EUID and generate <Link href="../ref-info/glossary-uid#gl-euid-token">EUID tokens</Link> (advertising tokens) to be passed by Prebid.js or the Prebid Mobile SDK in the RTB bidstream. |
+| Prebid.js Client-Side Integration | [EUID Client-Side Integration Guide for Prebid.js](../guides/integration-prebid-client-side.md) | A guide for publishers who want to request EUID tokens client-side, which is the easiest implementation approach, and choose to have Prebid.js manage the following: <ul><li>Token generation and <a href="../ref-info/glossary-uid#gl-token-refresh">token refresh</a>.</li><li>Passing the tokens into the RTB bidstream.</li></ul> |
+| Prebid.js Client-Server Integration | [EUID Client-Server Integration Guide for Prebid.js](../guides/integration-prebid-client-server.md) | A guide for publishers who want to integrate with EUID and generate EUID tokens to be passed by Prebid.js in the RTB bidstream, but want to generate tokens server-side: for example, publishers who are using a <Link href="../ref-info/glossary-uid#gl-private-operator">Private Operator</Link>. |
+| JavaScript (Overview) | [EUID Integration Overview for JavaScript](../guides/integration-javascript.md) | An overview of options for publishers who want to integrate with EUID using the JavaScript SDK. |
+| JavaScript Client-Side Integration | [Client-Side Integration Guide for JavaScript](../guides/integration-javascript-client-side.md) | A guide for publishers who want to integrate with EUID using only client-side JavaScript changes, which is the easiest implementation approach.<br/>The SDK for JavaScript manages token generation and token refresh automatically. |
+| JavaScript Client-Server Integration | [Client-Server Integration Guide for JavaScript](../guides/integration-javascript-client-server.md) | A publisher guide covering standard web integration scenarios that use the SDK for JavaScript and require tokens to be generated on the server side and passed to the publisher web pages. |
+| Server-Side Integration | [Publisher Integration Guide, Server-Side](../guides/integration-publisher-server-side.md) | A guide for publishers who do not use the [SDK for JavaScript](../sdks/sdk-ref-javascript.md). |
+| Publisher/SSP Integration with GAM | [Google Ad Manager Secure Signals Integration Guide](../guides/integration-google-ss.md) | A guide covering the additional steps needed for publishers using EUID with the Google Ad Manager Secure Signals feature (previously known as Encrypted Signals for Publishers, ESP). |
+
+### Mobile Integrations
+
+The following resources are available for publisher integrations supporting Android or iOS devices.
+
+| Integration Type| Documentation | Content Description |
+| :--- | :--- | :--- |
+| Android/iOS (Overview) | [Mobile Integration Overview for Android and iOS](../guides/integration-mobile-overview.md) | An overview of options for mobile app publishers who want to integrate with EUID using the SDK for Android or the SDK for iOS. |
+| Android/iOS, Client-Side Integration | [Client-Side Integration Guide for Mobile](../guides/integration-mobile-client-side.md) | An integration guide for mobile app publishers who want to integrate with EUID with changes only within the mobile app (no server-side changes). |
+| Android/iOS, Client-Server Integration | [Client-Server Integration Guide for Mobile](../guides/integration-mobile-client-server.md) | An integration guide for mobile app publishers who want to integrate with EUID by doing the following:<ol><li>Generating EUID tokens server-side via either a Public or Private Operator.</li><li>Passing the resulting <Link href="../ref-info/glossary-uid#gl-identity">identities</Link> to a mobile app for passing into the bidstream.</li></ol> |
+| Android/iOS, Server-Side Integration | [Server-Side Integration Guide for Mobile](../guides/integration-mobile-server-side.md) | An integration guide for mobile app publishers who want to manage the EUID token entirely on the server side. |
+| Android | [SDK for Android Reference Guide](../sdks/sdk-ref-android.md) |An SDK that facilitates the process of generating or establishing client identity using EUID and retrieving EUID tokens for publishers that need to support Android apps. |
+| iOS | [SDK for iOS Reference Guide](../sdks/sdk-ref-ios.md) | An SDK that facilitates the process of generating or establishing client identity using EUID and retrieving EUID tokens for publishers that need to support iOS apps. |
+
+### CTV Integrations
+
+The following resources are available for publisher integrations supporting CTV.
+
+| Integration Type| Documentation | Content Description |
+| :--- | :--- | :--- |
+| CTV | [CTV Integration Guide](../guides/integration-ctv-guide.md) | A summary of CTV integration options, with links to additional information and instructions. |
+
+### Prebid Integrations
+
+The following resources are available for publishers integrating with Prebid.
+
+| Integration Type| Documentation | Content Description |
+| :--- | :--- | :--- |
+| Prebid (Overview) | [EUID Integration Overview for Prebid](../guides/integration-prebid.md) | An overview of options for publishers who want to integrate with EUID and generate <Link href="../ref-info/glossary-uid#gl-euid-token">EUID tokens</Link> (advertising tokens) to be passed by Prebid.js or the Prebid Mobile SDK in the RTB bidstream. |
+| Prebid.js Client-Side Integration | [EUID Client-Side Integration Guide for Prebid.js](../guides/integration-prebid-client-side.md) | A guide for publishers who want to request EUID tokens client-side, which is the easiest implementation approach, and choose to have Prebid.js manage the following: <ul><li>Token generation and <a href="../ref-info/glossary-uid#gl-token-refresh">token refresh</a>.</li><li>Passing the tokens into the RTB bidstream.</li></ul> |
+| Prebid.js Client-Server Integration | [EUID Client-Server Integration Guide for Prebid.js](../guides/integration-prebid-client-server.md) | A guide for publishers who want to integrate with EUID and generate EUID tokens to be passed by Prebid.js in the RTB bidstream, but want to generate tokens server-side: for example, publishers who are using a Private Operator. |
+| Prebid.js on Mobile | [EUID Mobile Integration for Prebid.js](../guides/integration-prebid-mobile-summary.md) | A summary of information resources for EUID integration with Prebid.js on mobile devices. |
+
+### Google Ad Manager Integrations
+
+The following resources are available for publishers integrating with Google Ad Manager.
+
+| Integration Type| Documentation | Content Description |
+| :--- | :--- | :--- |
+| Publisher/SSP Integration with GAM | [Google Ad Manager Secure Signals Integration Guide](../guides/integration-google-ss.md) | A guide covering the additional steps needed for publishers using EUID with the Google Ad Manager Secure Signals feature (previously known as Encrypted Signals for Publishers, ESP). |
+| GMA for Android | [EUID GMA Plugin for Android Integration Guide](../guides/mobile-plugin-gma-android.md) | A guide that enables publishers using the Google Mobile Ads (GMA) SDK to include EUID tokens in ad requests from their Android apps. |
+| GMA for iOS | [EUID GMA Plugin for iOS Integration Guide](../guides/mobile-plugin-gma-ios.md) | A guide that enables publishers using the Google Mobile Ads (GMA) SDK to include EUID tokens in ad requests from their iOS apps. |
+| IMA for Android | [EUID IMA Plugin for Android Integration Guide](../guides/mobile-plugin-ima-android.md) | A guide that enables publishers using the Google Interactive Media Ads (IMA) SDK to include EUID tokens in ad requests from their Android apps. |
+| IMA for iOS | [EUID IMA Plugin for iOS Integration Guide](../guides/mobile-plugin-ima-ios.md) | A guide that enables publishers using the Google Interactive Media Ads (IMA) SDK to include EUID tokens in ad requests from their iOS apps. |

--- a/sidebars.js
+++ b/sidebars.js
@@ -82,7 +82,8 @@ const fullSidebar = [
           type: 'category',
           label: 'Publisher Integrations',
           link: {
-            type: 'generated-index',
+            type: 'doc',
+            id: 'guides/integration-options-publisher-all',
           },
           collapsed: true,
 


### PR DESCRIPTION
Minor mods to Publisher docs:
- Add private operator info
- Add top-level file for publisher integration options