### PR TITLE
UID2-6871: Fix CVE-2026-4800 lodash arbitrary code execution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10584,10 +10584,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "serialize-javascript": "^7.0.3",
     "svgo": "^3.3.3",
     "node-forge": "^1.4.0",
-    "picomatch": "^2.3.2"
+    "picomatch": "^2.3.2",
+    "lodash": ">=4.18.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary

Fixes CVE-2026-4800 (HIGH severity) in `lodash` — arbitrary code execution via untrusted input in template imports.

- Adds `"lodash": ">=4.18.0"` to `overrides` in `package.json`
- Regenerated lockfile now resolves lodash to `4.18.1`

## References

- CVE: https://avd.aquasec.com/nvd/cve-2026-4800
- Jira: https://thetradedesk.atlassian.net/browse/UID2-6871

🤖 Generated with [Claude Code](https://claude.com/claude-code)