### PR TITLE
UID2-6917 Add 20 concurrent requests restriction for /identity/map

### DIFF
--- a/docs/endpoints/post-identity-map-v2.md
+++ b/docs/endpoints/post-identity-map-v2.md
@@ -29,7 +29,7 @@ If you're using an earlier version, we recommend that you upgrade as soon as pos
 Here's what you need to know:
 
 - The maximum request size is 1MB.
-- To map a large number of email addresses, phone numbers, or their respective hashes, send them in batches with a maximum of 5,000 items per batch. You may send up to 20 batches in parallel.
+- To map a large number of email addresses, phone numbers, or their respective hashes, send them in batches with a maximum of 5,000 items per batch. We recommend sending no more than 20 batches in parallel.
 - Be sure to store mappings of email addresses, phone numbers, or their respective hashes.<br/>Not storing mappings could increase processing time drastically when you have to map millions of email addresses. Recalculating only those mappings that actually need to be updated, however, reduces the total processing time because only about 1/365th of raw EUIDs need to be updated daily. See also [Advertiser/Data Provider Integration Overview](../guides/integration-advertiser-dataprovider-overview.md) and [FAQs for Advertisers and Data Providers](../getting-started/gs-faqs.md#faqs-for-advertisers-and-data-providers).
 
 ## Rate Limiting

--- a/docs/endpoints/post-identity-map-v2.md
+++ b/docs/endpoints/post-identity-map-v2.md
@@ -24,12 +24,12 @@ This documentation is for version 2 of this endpoint, which is not the latest ve
 If you're using an earlier version, we recommend that you upgrade as soon as possible, to take advantage of improvements. For migration guidance, see [Migration from v2 Identity Map](post-identity-map.md#migration-from-v2-identity-map). For deprecation information, see [Deprecation Schedule: Endpoint Versions](../ref-info/deprecation-schedule.md#endpoint-versions).
 :::
 
-## Batch Size Requirements
+## Batch Size and Request Parallelization Requirements
 
 Here's what you need to know:
 
 - The maximum request size is 1MB.
-- To map a large number of email addresses, phone numbers, or their respective hashes, send them in batches with a maximum of 5,000 items per batch.
+- To map a large number of email addresses, phone numbers, or their respective hashes, send them in batches with a maximum of 5,000 items per batch. You may send up to 20 batches in parallel.
 - Be sure to store mappings of email addresses, phone numbers, or their respective hashes.<br/>Not storing mappings could increase processing time drastically when you have to map millions of email addresses. Recalculating only those mappings that actually need to be updated, however, reduces the total processing time because only about 1/365th of raw EUIDs need to be updated daily. See also [Advertiser/Data Provider Integration Overview](../guides/integration-advertiser-dataprovider-overview.md) and [FAQs for Advertisers and Data Providers](../getting-started/gs-faqs.md#faqs-for-advertisers-and-data-providers).
 
 ## Rate Limiting

--- a/docs/endpoints/post-identity-map.md
+++ b/docs/endpoints/post-identity-map.md
@@ -23,12 +23,12 @@ This documentation is for the latest version of this endpoint, version 3.
 
 If needed, documentation is also available for the previous version: see [POST /identity/map (v2)](post-identity-map-v2.md).
 
-## Batch Size Requirements
+## Batch Size and Request Parallelization Requirements
 
 Here's what you need to know:
 
 - The maximum request size is 1MB.
-- To map a large number of email addresses, phone numbers, or their respective hashes, send them in batches with a maximum of 5,000 items per batch.
+- To map a large number of email addresses, phone numbers, or their respective hashes, send them in batches with a maximum of 5,000 items per batch. You may send up to 20 batches in parallel.
 - Be sure to store mappings of email addresses, phone numbers, or their respective hashes.<br/>Not storing mappings could increase processing time drastically when you have to map millions of email addresses or phone numbers. Recalculating only those mappings that actually need to be updated, however, reduces the total processing time because only about 1/365th of EUIDs need to be updated daily. See also [Advertiser/Data Provider Integration Overview](../guides/integration-advertiser-dataprovider-overview.md) and [FAQs for Advertisers and Data Providers](../getting-started/gs-faqs.md#faqs-for-advertisers-and-data-providers).
 
 ## Rate Limiting

--- a/docs/endpoints/post-identity-map.md
+++ b/docs/endpoints/post-identity-map.md
@@ -28,7 +28,7 @@ If needed, documentation is also available for the previous version: see [POST /
 Here's what you need to know:
 
 - The maximum request size is 1MB.
-- To map a large number of email addresses, phone numbers, or their respective hashes, send them in batches with a maximum of 5,000 items per batch. You may send up to 20 batches in parallel.
+- To map a large number of email addresses, phone numbers, or their respective hashes, send them in batches with a maximum of 5,000 items per batch. We recommend sending no more than 20 batches in parallel.
 - Be sure to store mappings of email addresses, phone numbers, or their respective hashes.<br/>Not storing mappings could increase processing time drastically when you have to map millions of email addresses or phone numbers. Recalculating only those mappings that actually need to be updated, however, reduces the total processing time because only about 1/365th of EUIDs need to be updated daily. See also [Advertiser/Data Provider Integration Overview](../guides/integration-advertiser-dataprovider-overview.md) and [FAQs for Advertisers and Data Providers](../getting-started/gs-faqs.md#faqs-for-advertisers-and-data-providers).
 
 ## Rate Limiting

--- a/docs/ref-info/updates-doc.md
+++ b/docs/ref-info/updates-doc.md
@@ -16,6 +16,26 @@ import CustomTagsContainer from '@site/src/components/CustomTags/CustomTagsConta
 
 Check out the latest updates to our EUID documentation resources.
 
+## Q2 2026
+
+The following documents were released in the second quarter of 2026.
+
+<CustomTagsContainer tags="Endpoints">
+
+### Request Parallelization Updates for POST /identity/map
+
+April 17, 2026
+
+The [POST&nbsp;/identity/map](../endpoints/post-identity-map.md) endpoint documentation has been updated with the following changes:
+
+- Added a recommendation to send up to 20 /identity/map batches in parallel.
+
+These changes apply to both [v2](../endpoints/post-identity-map-v2.md) and [v3](../endpoints/post-identity-map.md) endpoints.
+
+<!-- UID2-6917 -->
+
+</CustomTagsContainer>
+
 ## Q1 2026
 
 The following documents were released in the first quarter of 2026.

--- a/docs/ref-info/updates-doc.md
+++ b/docs/ref-info/updates-doc.md
@@ -36,10 +36,6 @@ These changes apply to both [v2](../endpoints/post-identity-map-v2.md) and [v3](
 
 </CustomTagsContainer>
 
-## Q1 2026
-
-The following documents were released in the first quarter of 2026.
-
 <CustomTagsContainer tags="Endpoints">
 
 ### Rate Limiting and Parallel Request Updates for POST /identity/map
@@ -56,6 +52,10 @@ These changes apply to both [v2](../endpoints/post-identity-map-v2.md) and [v3](
 <!-- UID2-6642 -->
 
 </CustomTagsContainer>
+
+## Q1 2026
+
+The following documents were released in the first quarter of 2026.
 
 <CustomTagsContainer tags="Endpoints, SDKs, Opt-Out">
 

--- a/docs/ref-info/updates-doc.md
+++ b/docs/ref-info/updates-doc.md
@@ -22,22 +22,6 @@ The following documents were released in the second quarter of 2026.
 
 <CustomTagsContainer tags="Endpoints">
 
-### Request Parallelization Updates for POST /identity/map
-
-April 17, 2026
-
-The [POST&nbsp;/identity/map](../endpoints/post-identity-map.md) endpoint documentation has been updated with the following changes:
-
-- Added a recommendation to send up to 20 /identity/map batches in parallel.
-
-These changes apply to both [v2](../endpoints/post-identity-map-v2.md) and [v3](../endpoints/post-identity-map.md) endpoints.
-
-<!-- UID2-6917 -->
-
-</CustomTagsContainer>
-
-<CustomTagsContainer tags="Endpoints">
-
 ### Rate Limiting and Parallel Request Updates for POST /identity/map
 
 April 1, 2026


### PR DESCRIPTION
- Add our suggested limit of 20 concurrent requests for `/identity/map` endpoints
- Fix Documentation Updates entry that was in the wrong quarter