### PR TITLE
UID2-6896 Add source_ref input so we can deploy previews from branches

### DIFF
--- a/.github/workflows/deployPreview.yml
+++ b/.github/workflows/deployPreview.yml
@@ -8,6 +8,11 @@ on:
   #push:
     #branches: []
   workflow_dispatch:
+    inputs:
+      source_ref:
+        description: "Ref of EUID-docs to deploy as preview (branch name, tag, or full SHA). Defaults to main."
+        type: string
+        default: main
 
 permissions:
   contents: read
@@ -24,9 +29,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: ci-auto-merge
     steps:
-      - name: Checkout source
+      - name: Checkout source at requested ref
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ inputs.source_ref }}
+          path: source
           persist-credentials: false
 
       - name: Checkout target preview repo
@@ -41,8 +48,11 @@ jobs:
           rsync -arv --delete --delete-excluded \
             --exclude=".github" \
             --exclude=".git" \
-            --exclude="preview-target" \
-            ./ preview-target/preview/
+            source/ preview-target/preview/
+
+      - name: Resolve source SHA for traceability
+        id: source-sha
+        run: echo "sha=$(git -C source rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Create PR with sync changes
         id: cpr
@@ -52,9 +62,9 @@ jobs:
           token: ${{ secrets.GH_MERGE_TOKEN }}
           branch: ci-deploy-preview
           delete-branch: true
-          commit-message: "[CI Pipeline] Deploy preview from ${{ github.sha }}"
-          title: "[CI Pipeline] Deploy preview from ${{ github.sha }}"
-          body: "Automated preview deployment from ${{ github.repository }}@${{ github.sha }}"
+          commit-message: "[CI Pipeline] Deploy preview from EUID-docs ${{ inputs.source_ref }} @ ${{ steps.source-sha.outputs.sha }}"
+          title: "[CI Pipeline] Deploy preview from EUID-docs ${{ inputs.source_ref }}"
+          body: "Automated preview deployment from `EUID-docs` ref `${{ inputs.source_ref }}` (SHA `${{ steps.source-sha.outputs.sha }}`)."
 
       - name: Merge PR as UID2SourceAdmin
         if: steps.cpr.outputs.pull-request-number != ''

--- a/.github/workflows/deployPreview.yml
+++ b/.github/workflows/deployPreview.yml
@@ -62,9 +62,9 @@ jobs:
           token: ${{ secrets.GH_MERGE_TOKEN }}
           branch: ci-deploy-preview
           delete-branch: true
-          commit-message: "[CI Pipeline] Deploy preview from EUID-docs ${{ inputs.source_ref }} @ ${{ steps.source-sha.outputs.sha }}"
-          title: "[CI Pipeline] Deploy preview from EUID-docs ${{ inputs.source_ref }}"
-          body: "Automated preview deployment from `EUID-docs` ref `${{ inputs.source_ref }}` (SHA `${{ steps.source-sha.outputs.sha }}`)."
+          commit-message: "[CI Pipeline] Deploy preview from ${{ github.repository }} ${{ inputs.source_ref }} @ ${{ steps.source-sha.outputs.sha }}"
+          title: "[CI Pipeline] Deploy preview from ${{ github.repository }} ${{ inputs.source_ref }}"
+          body: "Automated preview deployment from `${{ github.repository }}` ref `${{ inputs.source_ref }}` (SHA `${{ steps.source-sha.outputs.sha }}`)."
 
       - name: Merge PR as UID2SourceAdmin
         if: steps.cpr.outputs.pull-request-number != ''


### PR DESCRIPTION
**Summary**
Adds a `source_ref` input to the `Deploy to Preview Site` workflow. This workflow now must be dispatched from `main` (the `ci-auto-merge` env already enforces this), but `source_ref` now allows feature branches to be deployed to the preview.

**rsync changes**
```
previous layout
  ./                        ← rsync source ("./") and EUID-docs working tree
  ├── .git/
  ├── .github/              ← excluded
  ├── docs/, src/, ...
  └── preview-target/       ← cloned euid-docs-preview, INSIDE the rsync source tree
      ├── .git/
      └── preview/          ← rsync destination ("preview-target/preview/")

new layout
  ./
  ├── source/               ← rsync source ("source/"), EUID-docs at source_ref
  │   ├── .git/             ← still excluded
  │   ├── .github/          ← still excluded
  │   └── docs/, src/, ...
  └── preview-target/       ← cloned euid-docs-preview, SIBLING of source/
      ├── .git/
      └── preview/          ← rsync destination
```