### PR TITLE
UID2-7173 2026 H1 Private Operator release

### DIFF
--- a/docs/guides/operator-guide-aws-marketplace.md
+++ b/docs/guides/operator-guide-aws-marketplace.md
@@ -37,7 +37,7 @@ The latest ZIP file is linked in the Release Notes column in the following table
 
 | Version Name | Version&nbsp;#/Release&nbsp;Notes | AWS Version |  Date |
 | ------- | ------ | ------ | ------ | 
-| Q4 2025 | [v5.62.24](https://github.com/IABTechLab/uid2-operator/releases/tag/v5.62.24-r2) | 5.62.24 | January 15, 2026 |
+| H1 2026 | [v5.70.159](https://github.com/IABTechLab/uid2-operator/releases/tag/v5.70.159-r0) | 5.70.159 | June 23, 2026 |
 
 :::note
 For information about supported versions and deprecation dates, see [Private Operator versions](../ref-info/deprecation-schedule.md#private-operator-versions).

--- a/docs/ref-info/deprecation-schedule.md
+++ b/docs/ref-info/deprecation-schedule.md
@@ -32,6 +32,7 @@ The latest ZIP file is available in the Assets section at the bottom of the link
 
 | Version Name | Version&nbsp;#/Release&nbsp;Notes | AWS Version |  Date | Deprecation Date |
 | ------- | ------ | ------ | ------ | ------ |
+| H1 2026 | [v5.70.159](https://github.com/IABTechLab/uid2-operator/releases/tag/v5.70.159-r0) | 5.70.159 | June 23, 2026 | June 30, 2027 |
 | Q4 2025 | [v5.62.24](https://github.com/IABTechLab/uid2-operator/releases/tag/v5.62.24-r2) | 5.62.24 | January 15, 2026 | January 15, 2027 |
 | Q2 2025 | [v5.55.9](https://github.com/IABTechLab/uid2-operator/releases/tag/v5.55.9-r1) | 5.55.9 | July 1, 2025 | July 1, 2026 |
 | Q1 2025 | [v5.49.7](https://github.com/IABTechLab/uid2-operator/releases/tag/v5.49.7) | 5.49.7 | Mar 19, 2025 | Mar 31, 2026 |


### PR DESCRIPTION
Update AWS version to point to the new release. Also update deprecation schedule to include the new release.