### PR TITLE
UID2-7375 Reference UID Verify from publisher web integration guides

### DIFF
--- a/docs/guides/integration-google-ss.md
+++ b/docs/guides/integration-google-ss.md
@@ -11,6 +11,7 @@ displayed_sidebar: docs
 import Link from '@docusaurus/Link';
 import SnptIntegratingWithSSO from '../snippets/_snpt-integrating-with-sso.mdx';
 import SnptPreparingEmailsAndPhoneNumbers from '../snippets/_snpt-preparing-emails-and-phone-numbers.mdx';
+import SnptUidVerifyInspect from '../snippets/_snpt-uid-verify-inspect.mdx';
 
 # Google Ad Manager Secure Signals integration guide
 
@@ -66,6 +67,10 @@ If you want to use Secure Signals with Prebid.js, you must complete both these a
 ## Integrating with single sign-on (SSO)
 
 <SnptIntegratingWithSSO />
+
+## Inspecting with UID Verify Chrome extension
+
+<SnptUidVerifyInspect />
 
 ## Preparing personal data for processing
 

--- a/docs/guides/integration-javascript-client-server.md
+++ b/docs/guides/integration-javascript-client-server.md
@@ -13,6 +13,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import SnptIntegratingWithSSO from '../snippets/_snpt-integrating-with-sso.mdx';
 import SnptPreparingEmailsAndPhoneNumbers from '../snippets/_snpt-preparing-emails-and-phone-numbers.mdx';
+import SnptUidVerifyInspect from '../snippets/_snpt-uid-verify-inspect.mdx';
 
 # Client-server integration guide for JavaScript
 
@@ -55,6 +56,10 @@ If you are using Google Ad Manager and want to use the secure signals feature, f
 ## Integrating with single sign-on (SSO)
 
 <SnptIntegratingWithSSO />
+
+## Inspecting with UID Verify Chrome extension
+
+<SnptUidVerifyInspect />
 
 ## Preparing personal data for processing
 

--- a/docs/guides/integration-javascript-client-side.md
+++ b/docs/guides/integration-javascript-client-side.md
@@ -13,6 +13,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import SnptIntegratingWithSSO from '../snippets/_snpt-integrating-with-sso.mdx';
 import SnptPreparingEmailsAndPhoneNumbers from '../snippets/_snpt-preparing-emails-and-phone-numbers.mdx';
+import SnptUidVerifyInspect from '../snippets/_snpt-uid-verify-inspect.mdx';
 
 export const New370 = () => (
   <span className='pill'>New in version 3.7.0</span>
@@ -54,6 +55,10 @@ If you want to use a debug build of the SDK, use the following URL instead:
 ## Integrating with single sign-on (SSO)
 
 <SnptIntegratingWithSSO />
+
+## Inspecting with UID Verify Chrome extension
+
+<SnptUidVerifyInspect />
 
 ## Preparing personal data for processing
 

--- a/docs/guides/integration-options-publisher-web.md
+++ b/docs/guides/integration-options-publisher-web.md
@@ -7,6 +7,8 @@ displayed_sidebar: sidebarPublishers
 ---
 
 import Link from '@docusaurus/Link';
+import SnptIntegratingWithSSO from '../snippets/_snpt-integrating-with-sso.mdx';
+import SnptUidVerifyInspect from '../snippets/_snpt-uid-verify-inspect.mdx';
 import SnptPreparingEmailsAndPhoneNumbers from '../snippets/_snpt-preparing-emails-and-phone-numbers.mdx';
 
 # Publisher web integration overview
@@ -43,6 +45,14 @@ To accomplish all steps, you can combine solutions. For example, you could use t
 | [Google Ad Manager Secure Signals](integration-google-ss.md) | &#8212; | &#8212; | &#9989; |
 
 <!-- &#9989; = Supported | &#8212; = Not Supported -->
+
+## Integrating with single sign-on (SSO)
+
+<SnptIntegratingWithSSO />
+
+## Inspecting with UID Verify Chrome extension
+
+<SnptUidVerifyInspect />
 
 ## Preparing personal data for processing
 

--- a/docs/guides/integration-prebid-client-server.md
+++ b/docs/guides/integration-prebid-client-server.md
@@ -13,6 +13,7 @@ import SnptIntegratingWithSSO from '../snippets/_snpt-integrating-with-sso.mdx';
 import SnptPreparingEmailsAndPhoneNumbers from '../snippets/_snpt-preparing-emails-and-phone-numbers.mdx';
 import SnptAddPrebidjsToYourSite from '../snippets/_snpt-prebid-add-prebidjs-to-your-site.mdx';
 import SnptStoreEUIDTokenInBrowser from '../snippets/_snpt-prebid-storing-euid-token-in-browser.mdx';
+import SnptUidVerifyInspect from '../snippets/_snpt-uid-verify-inspect.mdx';
 
 # Client-server integration guide for Prebid.js
 
@@ -40,6 +41,10 @@ Information about how to integrate Prebid with EUID is also in the following loc
 ## Integrating with single sign-on (SSO)
 
 <SnptIntegratingWithSSO />
+
+## Inspecting with UID Verify Chrome extension
+
+<SnptUidVerifyInspect />
 
 ## Preparing personal data for processing
 

--- a/docs/guides/integration-prebid-client-side.md
+++ b/docs/guides/integration-prebid-client-side.md
@@ -13,6 +13,7 @@ import SnptIntegratingWithSSO from '../snippets/_snpt-integrating-with-sso.mdx';
 import SnptPreparingEmailsAndPhoneNumbers from '../snippets/_snpt-preparing-emails-and-phone-numbers.mdx';
 import SnptAddPrebidjsToYourSite from '../snippets/_snpt-prebid-add-prebidjs-to-your-site.mdx';
 import SnptStoreEUIDTokenInBrowser from '../snippets/_snpt-prebid-storing-euid-token-in-browser.mdx';
+import SnptUidVerifyInspect from '../snippets/_snpt-uid-verify-inspect.mdx';
 
 # Client-side integration guide for Prebid.js
 
@@ -31,6 +32,10 @@ If you need to use an earlier version of Prebid.js, use the implementation solut
 ## Integrating with single sign-on (SSO)
 
 <SnptIntegratingWithSSO />
+
+## Inspecting with UID Verify Chrome extension
+
+<SnptUidVerifyInspect />
 
 ## Preparing personal data for processing
 

--- a/docs/snippets/_snpt-uid-verify-inspect.mdx
+++ b/docs/snippets/_snpt-uid-verify-inspect.mdx
@@ -1,0 +1,3 @@
+<!-- Used by: guides/integration-google-ss.md | guides/integration-javascript-client-server.md | guides/integration-javascript-client-side.md | guides/integration-prebid-client-server.md | guides/integration-prebid-client-side.md |(5 files) -->
+
+You can use the [UID Verify Chrome extension](../ref-info/ref-uid-verify.md) to inspect and debug your EUID web integration directly in Chrome. UID Verify supports the SDK for JavaScript, Prebid.js, and Google Secure Signals.


### PR DESCRIPTION
## Summary

EUID companion to [IABTechLab/uid2docs#1037](https://github.com/IABTechLab/uid2docs/pull/1037), mirroring its final (reworked) state.

UID Verify (the Chrome debugging extension) was previously documented only on its standalone reference page (`ref-info/ref-uid-verify`). It was not referenced from the publisher integration guides.

This PR adds a shared snippet (`docs/snippets/_snpt-uid-verify-inspect.mdx`) pointing to the UID Verify reference page, framed as a debugging/inspection aid (not a token-generation integration option), and imports it into an **"Inspecting with UID Verify Chrome extension"** section on:

**Hub page:**
- `docs/guides/integration-options-publisher-web.md` — new "Integrating with SSO" + "Inspecting with UID Verify Chrome extension" sections

**Individual web guides** (the integration types UID Verify supports):
- `integration-javascript-client-side.md`
- `integration-javascript-client-server.md`
- `integration-prebid-client-side.md`
- `integration-prebid-client-server.md`
- `integration-google-ss.md`

The tip text lives in a single snippet so it stays consistent across all pages, positioned after the SSO snippet on each page. Additions only; no existing content changed. Pure server-side guide is excluded (nothing client-side for UID Verify to inspect).

## Jira
[UID2-7375](https://thetradedesk.atlassian.net/browse/UID2-7375)

## Related
UID2-docs PR: https://github.com/IABTechLab/uid2docs/pull/1037

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[UID2-7375]: https://thetradedesk.atlassian.net/browse/UID2-7375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ