### PR TITLE
UID2-7619: suppress CVE-2026-69152 in .trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -4,3 +4,9 @@
 # e.g. 
 # CVE-2022-3996
 
+# CVE-2026-69152 — brace-expansion (npm) (HIGH).
+# Not exploitable here: package.json overrides brace-expansion@5=5.0.8; docusaurus static-site
+# generator (scripts: docusaurus build/start). Pulled transitively via minimatch/glob at build
+# time only; production artifact is static HTML/JS with no expand() on runtime input.
+# See: UID2-7619
+CVE-2026-69152 exp:2026-09-06


### PR DESCRIPTION
Suppresses **CVE-2026-69152** (HIGH, `brace-expansion (npm)`) — present in the image but not reachable from this service. Expiry **2026-09-06** (1 month). No code fix.

**Why:** DoS in brace-expansion expand() (unbounded intermediate arrays / padded sequences; maxLength not applied), bypassing the CVE-2026-14257 fix. Exploitation requires the application to call expand() on attacker-controlled brace patterns. In all six repos brace-expansion is a purely transitive dependency of minimatch/glob used by build tooling, linters and test/dev runners (Docusaurus static-site builds, craco/React builds, eslint/jest/nodemon). No repo invokes minimatch/glob/brace-expansion on network- or attacker-supplied input at runtime; the docs sites ship static assets with no server-side expansion. The vulnerable code path is therefore unreachable in production despite the vulnerable versions being present. Fixed versions exist but do not change a not_affected verdict.

**Evidence:** package.json overrides brace-expansion@5=5.0.8; docusaurus static-site generator (scripts: docusaurus build/start). Pulled transitively via minimatch/glob at build time only; production artifact is static HTML/JS with no expand() on runtime input. package.json overrides brace-expansion@5=5.0.8; docusaurus static-site generator. Build-time-only glob/minimatch dependency; no runtime pattern expansion. preview/package.json overrides brace-expansion@5=5.0.8; docusaurus static-site generator. Same build-only chain as the other docs sites. package.json overrides brace-expansion@1=1.1.16, @5=5.0.8, plus @isaacs/brace-expansion override. craco/React frontend + tsx/nodemon dev API; no minimatch/glob/brace-expansion references in src. Reached only via build/lint/test tooling. yarn.lock has brace-expansion 1.1.16/2.1.2/5.0.7 all pulled only by minimatch under eslint-plugin-import, jest and nodemon (dev tooling). No minimatch/glob/brace-expansion use in src or bin; production start is `node ./build/bin/www`. Existing .trivyignore documents the same dev-only chain for CVE-2026-14257. brace-expansion@5=5.0.8 override across web-integrations sub-projects (server-side, javascript-sdk, google-secure-signals, prebid). Demo integration apps; no minimatch/glob/brace-expansion invocation in the example JS sources — reached only via build tooling.

Reachability alone determines suppress-vs-fix — a fixed version existing upstream does not make an unreachable path exploitable. Change the expiry in review if you want a different window.

<details>
<summary>Full triage report</summary>

### CVE-2026-69152 — brace-expansion DoS (bypass of CVE-2026-14257 fix)

#### What the CVE is
`brace-expansion`'s `expand()` does not apply its `maxLength` guard while constructing
comma-alternative intermediate arrays or padded sequences. An attacker who controls the
brace pattern passed to `expand()` can force construction of huge intermediate arrays,
exhausting memory or blocking the Node.js event loop — a denial of service. This bypasses
the earlier CVE-2026-14257 fix. CVSS 3.1 HIGH (AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H).

- **Vulnerable:** `<1.1.18`, `<2.1.4`, `<3.0.6`, `<5.0.9`
- **Fixed:** 1.1.18 / 2.1.4 / 3.0.6 / 5.0.9
- **Exploit precondition:** the application must call `expand()` on attacker-supplied input.

#### Presence in our repos
All six flagged repos are JavaScript/Node projects and all carry a vulnerable
`brace-expansion` (mostly pinned to `5.0.8` via `overrides`/`resolutions`, plus
`5.0.7 / 2.1.2 / 1.1.16` in uid2-tcportal). These pins were introduced to remediate the
prior CVE-2026-14257; this new CVE bypasses that fix, so the pinned versions are
present-and-vulnerable. So the package is **present** everywhere.

#### Reachability analysis (per repo)
The exploit needs `expand()` to run on attacker-controlled patterns. In every repo,
`brace-expansion` is only reached transitively through `minimatch`/`glob` (filesystem
glob matching), and only from build tooling, linters, or test/dev runners:

| Repo | Role | brace-expansion source | Runtime reachable? |
|------|------|------------------------|--------------------|
| EUID-docs | Docusaurus static site | build-time glob/minimatch | No — static HTML output |
| uid2docs | Docusaurus static site | build-time glob/minimatch | No — static HTML output |
| uid2-docs-preview | Docusaurus static site | build-time glob/minimatch | No — static HTML output |
| uid2-self-serve-portal | craco/React FE + tsx/nodemon dev API | build/lint/test tooling | No — no minimatch/glob use in `src` |
| uid2-tcportal | Express service | minimatch via eslint/jest/nodemon (dev) | No — no minimatch/glob use in `src`/`bin` |
| uid2-examples | demo integration apps | build tooling | No — no minimatch/glob use in example JS |

Key observations:
- The three docs repos are Docusaurus static-site generators; `brace-expansion` is used
  only during `docusaurus build`, and the deployed artifact is static HTML/JS with no
  server that expands patterns at request time.
- The portal's `src` contains no `minimatch`/`glob`/`brace-expansion` references; the chain
  is confined to craco/webpack build, eslint, jest and storybook.
- uid2-tcportal pulls brace-expansion only through `minimatch`, whose consumers are
  eslint-plugin-import, jest and nodemon — all dev tooling. Production start is
  `node -r dotenv/config ./build/bin/www` and the app source never calls glob/minimatch.
  The repo's existing `.trivyignore` already records this same dev-only reasoning for the
  predecessor CVE-2026-14257.
- uid2-examples are demonstration integration apps; the example JS never invokes
  glob/minimatch/brace-expansion.

No repo passes network- or attacker-controlled input into `expand()`.

#### Decision
**not_affected** across all six repos. The vulnerable code path is not reachable from any
production service or deployed artifact — exposure is limited to build/dev/test tooling.
Under the reachability-only decision logic, the availability of a fixed version does not
change this verdict.

**Recommended action:** suppress (record the entry in each repo's root `.trivyignore`).
Optionally, bumping the `brace-expansion` `overrides` pins to the fixed versions
(≥5.0.9 etc.) during routine dependency maintenance would clear the finding at source, but
it is not security-required given the lack of reachability.

**Confidence:** high — consistent across all six repos, corroborated by an existing
`.trivyignore` note for the sibling CVE.

</details>

---
_Opened by uid2-vul-scan-agent (general_use_claude-opus-4-8), verdict confidence high. Please sanity-check the reachability argument before approving._
