### PR TITLE
UID2-7633, UID2-7619: suppress 2 CVEs in .trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -9,10 +9,10 @@
 # via overrides in package.json:69; no source import of fast-uri; Docusaurus static-site build
 # tooling, no host-policy/fetch path
 # See: UID2-7633
-CVE-2026-18446 exp:2026-09-06
+CVE-2026-18446 exp:2026-11-06
 
 # CVE-2026-69152 — brace-expansion (npm, transitive via minimatch) (HIGH).
 # Not exploitable here: package-lock.json:6277 brace-expansion@5.0.8 via minimatch; Docusaurus
 # static-docs build tooling only; no runtime import
 # See: UID2-7619
-CVE-2026-69152 exp:2026-09-06
+CVE-2026-69152 exp:2026-11-06

--- a/.trivyignore
+++ b/.trivyignore
@@ -4,3 +4,15 @@
 # e.g. 
 # CVE-2022-3996
 
+# CVE-2026-18446 — fast-uri (transitive via ajv) (HIGH).
+# Not exploitable here: package-lock resolves fast-uri 3.1.4 as transitive dep of ajv; pinned
+# via overrides in package.json:69; no source import of fast-uri; Docusaurus static-site build
+# tooling, no host-policy/fetch path
+# See: UID2-7633
+CVE-2026-18446 exp:2026-09-06
+
+# CVE-2026-69152 — brace-expansion (npm, transitive via minimatch) (HIGH).
+# Not exploitable here: package-lock.json:6277 brace-expansion@5.0.8 via minimatch; Docusaurus
+# static-docs build tooling only; no runtime import
+# See: UID2-7619
+CVE-2026-69152 exp:2026-09-06


### PR DESCRIPTION
Suppresses **2 vulnerabilities** in `.trivyignore`, expiry **2026-11-06** (3 months). No code fixes — each is present in the image but not reachable from this service.

Reachability alone determines suppress-vs-fix: a fixed version existing upstream does not make an unreachable path exploitable. Change any expiry in review if you want a different window.

> **If another suppression PR is open on this repo, this one supersedes it.** Each scan run raises a fresh branch carrying every outstanding suppression, so the newest PR is a superset of the older ones — merge this and close the rest rather than merging both, which would conflict on the same append.

### CVE-2026-18446 — HIGH, `fast-uri (transitive via ajv)`

Host-confusion parser desync: fast-uri <=4.1.1 folds a backslash authority introducer into the path while Node's WHATWG URL treats it as a host, so callers that enforce host-based policy with fast-uri then reuse the URL in fetch/undici can be redirected. In every flagged repo fast-uri is only a transitive dependency of ajv (JSON-schema validator running in webpack/babel build tooling) — no application source imports fast-uri, and nothing uses it to gate hostnames before an outbound request. The vulnerable code path is therefore unreachable. Note: the repos' overrides pin fast-uri ^3.1.4 and resolve to 3.1.4, one patch short of the 3.1.5 fix, so the scanner still flags it.

<details>
<summary>Full triage report — CVE-2026-18446</summary>

### CVE-2026-18446 — fast-uri host confusion via backslash authority introducer

#### What the CVE is
`fast-uri` v4.1.1 and earlier only recognize a URI authority after a literal `//`. A reference using `\\`, `/\`, or `\/` as the authority introducer is parsed with **no authority** — the sequence and everything after it fold into the path. Node's native WHATWG `URL` (used by `fetch()`, `undici`, `http`/`https`) instead treats `\` as interchangeable with `/` for special schemes, so the two parsers extract **different hosts** from the same input. Applications that enforce host-based policy (allowlist/denylist, SSRF/loopback filtering, redirect validation, proxy routing) with `fast-uri` and then hand the same URL to a Node HTTP client see a policy/use desync and can be steered to an unintended host.
- Severity: HIGH — `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N`
- Fixed in: 2.4.4, 3.1.5, 4.1.2

#### How it maps onto our repos
| Repo | fast-uri present | Resolved version | How it's pulled in | Reachable? |
|------|------------------|------------------|--------------------|------------|
| EUID-docs | yes | 3.1.4 (prod) | transitive via `ajv`; override `^3.1.4` | no |
| uid2docs | yes | 3.1.4 (prod) | transitive via `ajv`; override `^3.1.4` | no |
| uid2-docs-preview | yes | 3.1.4 (prod) | transitive via `ajv`; override `^3.1.4` | no |
| uid2-self-serve-portal | yes | 3.1.4 (prod) | transitive via `ajv` (webpack/babel tooling); override `^3.1.4` | no |
| uid2-examples | yes | 3.1.4 (prod) / 3.1.2 (dev in 2 subprojects) | transitive via `ajv` | no |

Key observations from the code search:
- **No source file** in any repo imports `fast-uri` (`require('fast-uri')` / `import ... 'fast-uri'` → zero matches). Its only consumer is `ajv`, the JSON-schema validator, which sits under front-end build tooling (react-refresh-webpack-plugin, babel-loader, ajv-formats).
- These projects are static documentation sites (Docusaurus/CRA) and sample apps; ajv/fast-uri execute at **build time** for config/schema validation.
- The advisory's attack vector — parse a URL with fast-uri for host-based policy, then reuse it in a Node HTTP client — **does not exist** in our code. ajv uses fast-uri to validate URI *format* of schema strings, not to gate hostnames before an outbound `fetch`/`undici` request.

#### Decision
**not_affected.** The library is present (and, because the `overrides` pin resolves to 3.1.4 — one patch below the 3.1.5 fix — the scanner keeps flagging it), but the vulnerable code path is unreachable: there is no fast-uri-based host-policy enforcement anywhere in these repos.

#### Recommended remedy
Suppress this finding in the repo-root `.trivyignore` for each flagged repo (not-exploitable; unreachable path). Independently, if the team wants to clear the scan noise at source rather than suppress, they can raise the `fast-uri` override to `3.1.5` (the intended patch the current `^3.1.4` pin narrowly misses) — but this does not change the reachability verdict.

</details>

### CVE-2026-69152 — HIGH, `brace-expansion (npm, transitive via minimatch)`

brace-expansion is a build/lint/test-time transitive dependency (pulled through minimatch) in every flagged repo. The repos are Docusaurus documentation sites, static example apps, and a React+Express portal; none of their production runtime code imports brace-expansion, minimatch, or glob, and no production path passes attacker-controlled patterns to expand(). The advisory's DoS (unbounded intermediate arrays / event-loop block) requires reaching expand() with untrusted input, which is not reachable at runtime. A fixed 5.0.9 exists but availability does not change a not_affected verdict.

<details>
<summary>Full triage report — CVE-2026-69152</summary>

### CVE-2026-69152 — brace-expansion DoS via unbounded intermediate arrays

#### What the CVE is
`brace-expansion` versions before 1.1.18 / 2.1.4 / 3.0.6 / 5.0.9 contain a denial-of-service flaw (GHSA-rgw5-rvv9-x895). The `maxLength` mitigation added in 5.0.8 for CVE-2026-14257 is incomplete: it bounds the accumulator in `combine()` but not the intermediate `values` array built from comma-alternatives before combining. A ~25 KB crafted brace pattern can trigger an **uncatchable** out-of-memory crash (a `try/catch` around `expand()` does not help), and a related path lets a ~400 KB input block the event loop for minutes. CVSS 3.1 HIGH (AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H) — availability impact only.

To be exploitable, production code must pass attacker-controlled strings to `brace-expansion.expand()` — typically indirectly via `minimatch`/`glob` pattern matching on untrusted input.

#### Where it appears in our repos
`brace-expansion@5.0.8` is present in all six flagged repos. In every case it is a **transitive dependency of `minimatch`** (`minimatch` declares `brace-expansion: ^5.0.2`), and `minimatch`/`glob` are consumed by build, lint, test, and dev tooling — not by request-handling code:

| Repo | How present | Reachable at runtime? |
|------|-------------|-----------------------|
| uid2docs | be@5.0.8 ← minimatch@10.2.4 (Docusaurus build, eslint) | No |
| EUID-docs | be@5.0.8 ← minimatch (Docusaurus build) | No |
| uid2-docs-preview | be@5.0.8 ← minimatch (Docusaurus build) | No |
| uid2-examples | be@5.0.8 ← minimatch@10.2.4 (dev/build tooling); Express `server.js` requires only axios/express/cookie-session/ejs/nocache/crypto | No |
| uid2-self-serve-portal | be@5.0.8 ← minimatch (build/test tooling); no runtime import in `src/` | No |
| uid2-tcportal | be 1.1.16/2.1.2/5.0.7 ← eslint-plugin-import, jest, nodemon (all devDependencies) | No |

Notes:
- The docs sites (uid2docs, EUID-docs, uid2-docs-preview) are Docusaurus projects that emit static HTML. `brace-expansion` is only exercised during `docusaurus build`/lint, never in a served request.
- In uid2-examples and uid2-self-serve-portal, grep of runtime source found **no** imports of `brace-expansion`, `minimatch`, or `glob`. (The portal's direct `braces@3` dependency is a different package and unrelated to this CVE.)
- uid2-tcportal already ships a `.trivyignore` entry documenting brace-expansion as devDependency-only and not runtime-reachable (aligned with the earlier CVE-2026-14257 suppression).

#### Decision
**not_affected.** The vulnerable `expand()` path is confined to build/lint/test tooling in all six repos; no production runtime code feeds attacker-controlled input to brace-expansion (directly or via minimatch/glob). The DoS therefore cannot be triggered against any of our deployed services. A fixed release (5.0.9) exists, but per triage policy the availability of a fix does not convert a non-reachable finding into an affected one.

#### Recommended action
**Suppress** this CVE for all six repos (record the standard tracking/expiry via the repo-root `.trivyignore`). tcportal already has an equivalent entry; the others can follow the same devDependency-only rationale. Optionally, on the next routine dependency bump, allow the transitive `brace-expansion` to float to ≥5.0.9 (e.g. via the existing `overrides`/`resolutions` pins) to clear the scanner without any runtime risk change — but this is hygiene, not a security necessity.

</details>

---
_Opened by uid2-vul-scan-agent (general_use_claude-opus-4-8), verdict confidence high. Please sanity-check each reachability argument before approving._