### PR TITLE
UID2-7703, UID2-7704, UID2-7706, UID2-7705: suppress 4 CVEs in .trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -16,3 +16,45 @@ CVE-2026-18446 exp:2026-11-06
 # static-docs build tooling only; no runtime import
 # See: UID2-7619
 CVE-2026-69152 exp:2026-11-06
+
+# CVE-2025-71329 — image-size (HIGH).
+# Not exploitable here: package-lock.json:9931 installs image-size@2.0.2 solely as a transitive
+# dep of @docusaurus/mdx-loader (lock:3360 'image-size': '^2.0.2'). The repo is a Docusaurus
+# static docs site (package.json scripts: 'docusaurus build'/'serve'), no Dockerfile, no
+# runtime service. image-size is invoked at build time to measure the repo's own committed doc
+# images; there is no code path where a remote attacker supplies an image buffer. The
+# package.json override 'image-size@1':'^1.2.1' only rewrites v1 instances, so v2.0.2 remains,
+# but its JXL/HEIF parsers never receive untrusted input.
+# See: UID2-7703
+CVE-2025-71329 exp:2026-11-18
+
+# CVE-2025-71330 — image-size (HIGH).
+# Not exploitable here: package-lock.json:9931 pins image-size@2.0.2, pulled transitively by
+# @docusaurus/mdx-loader@3.9.2 (package-lock.json:3360). It is a build-time dependency used to
+# size images embedded in docs during `docusaurus build`; no runtime Node server invokes it on
+# untrusted input, no .icns files exist in the repo, and no src/ code imports image-size. The
+# package.json override only constrains image-size@1, not the v2 branch.
+# See: UID2-7704
+CVE-2025-71330 exp:2026-11-18
+
+# CVE-2026-67213 — nanoid (HIGH).
+# Not exploitable here: package-lock.json:13679 pins nanoid@3.3.16 solely as a transitive dep
+# of postcss@8.5.18 (line 14483, dependencies block). nanoid is not a direct dependency in
+# package.json; the only declared deps are Docusaurus/React build tooling. No source file under
+# docs/ or src/ imports nanoid or calls customAlphabet/customRandom (grep returned nothing).
+# postcss uses only the default nanoid() generator for internal identifiers with a fixed non-
+# zero size, never the customAlphabet/customRandom size=0 path. No Dockerfile/runtime service —
+# it is a static Docusaurus documentation site.
+# See: UID2-7706
+CVE-2026-67213 exp:2026-11-18
+
+# GHSA-5p4m-2wfm-xmqj — js-yaml (HIGH).
+# Not exploitable here: package.json overrides pin js-yaml@4->4.3.0 and js-yaml@3->3.15.0;
+# package-lock.json confirms both installed (js-yaml 4.3.0 root under @docusaurus/utils,
+# plugin-content-docs, utils-validation, eslint; js-yaml 3.15.0 nested under gray-matter). No
+# Dockerfile, no server, and no yaml.load/require('js-yaml')/import from 'js-yaml' anywhere in
+# src/. All consumers are build/dev-time (Docusaurus frontmatter+config parsing, eslint). Only
+# YAML parsed is repo-authored docs frontmatter/config — trusted content, no untrusted-input
+# path.
+# See: UID2-7705
+GHSA-5p4m-2wfm-xmqj exp:2026-11-18


### PR DESCRIPTION
Suppresses **4 vulnerabilities** in `.trivyignore`, expiry **2026-11-18** (3 months). No code fixes — each is present in the image but not reachable from this service.

Reachability alone determines suppress-vs-fix: a fixed version existing upstream does not make an unreachable path exploitable. Change any expiry in review if you want a different window.

> **If another suppression PR is open on this repo, this one supersedes it.** Each scan run raises a fresh branch carrying every outstanding suppression, so the newest PR is a superset of the older ones — merge this and close the rest rather than merging both, which would conflict on the same append.

### CVE-2025-71329 — HIGH, `image-size`

The CVE is a denial-of-service: a crafted image with a zero-valued box size in a JXL or HEIF container makes image-size's parser loop forever, hanging the Node.js event loop. Exploitation requires an attacker to feed a crafted image buffer to image-size. In EUID-docs the package is present (transitive dep of @docusaurus/mdx-loader, confirmed in package-lock.json at 2.0.2), but it runs only during the Docusaurus static-site build, where it measures the project's own trusted, version-controlled doc images. There is no Dockerfile, no server, and no runtime path that accepts user-supplied images — the built output is static HTML served without image-size in the loop. The attack vector (remote attacker-supplied crafted image) is therefore not reachable. Reachability of the vulnerable parser with untrusted input is what decides the verdict; a fixed version being unavailable does not change not_affected.

<details>
<summary>Full triage report — CVE-2025-71329</summary>

### CVE-2025-71329 — image-size DoS (JXL/HEIF infinite loop) in EUID-docs

#### The vulnerability
`image-size` through 2.0.2 (GHSA-5p2g-fcmc-qvqq, CVSS 3.1 HIGH, A:H) contains a denial-of-service flaw: a crafted image containing a box with a **zero-valued size field** in a recognized box-type causes the parser offset to never advance, sending the JXL or HEIF parser into an infinite loop and permanently blocking the Node.js event loop. Exploitation requires an attacker to supply a malicious image buffer to a code path that calls `image-size`.

#### Presence in our code
- `image-size@2.0.2` **is installed** in EUID-docs (`package-lock.json`), pulled in transitively as a dependency of `@docusaurus/mdx-loader` (`"image-size": "^2.0.2"`).
- The `overrides` block in `package.json` pins `image-size@1` to `^1.2.1`, but that selector only affects v1 instances; mdx-loader's `^2.0.2` requirement is unaffected, so the vulnerable v2.0.2 remains in the tree.

#### Reachability
EUID-docs is a **Docusaurus static documentation site** (scripts: `docusaurus build` / `serve`; no Dockerfile, no server component). `image-size` is used by mdx-loader **at build time** to compute dimensions for images embedded in the project's own markdown docs. Those images are trusted, committed repository content — not attacker-controlled. The published artifact is static HTML; `image-size` is not in any request-serving path. There is no scenario in which a remote attacker submits a crafted JXL/HEIF buffer to this parser.

The attack vector (remote-attacker-supplied crafted image) does not apply, so the vulnerable code path is **not reachable**.

#### Decision
**Verdict: not_affected.** The package is present but only exercises trusted, build-time input; the DoS requires untrusted image input that this deployment never processes. No fixed version is currently named in the advisory, which does not change the verdict. Recommended action: **suppress** this finding (repo-root `.trivyignore`). Revisit if EUID-docs ever gains a runtime service that parses user-supplied images.

</details>

### CVE-2025-71330 — HIGH, `image-size`

The vulnerability is an infinite-loop DoS triggered when the ICNS parser is fed a crafted ICNS buffer with a zero-valued entry length; exploitation requires a remote attacker to supply untrusted image bytes to image-size at runtime. In EUID-docs, image-size@2.0.2 is present only as a transitive build-time dependency of @docusaurus/mdx-loader, which calls it during `docusaurus build` to compute dimensions of trusted, in-repo images referenced in markdown/MDX. The deployed artifact is a static Docusaurus site — there is no running Node event loop that parses attacker-controlled image input. No source code references image-size, and there are no ICNS files. The attacker-controlled-input precondition therefore does not hold, so the vulnerable code path is unreachable. A fixed version being unavailable does not change this: an unreachable path is suppressed regardless.

<details>
<summary>Full triage report — CVE-2025-71330</summary>

#### CVE-2025-71330 — image-size ICNS infinite-loop DoS (HIGH)

**Package:** image-size (installed 2.0.2; vulnerable "through 2.0.2"; no fixed version published at triage time)
**Advisory:** GHSA-w3rx-r6r6-pgpr / CVSS:3.1 AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
**Flagged in:** EUID-docs (`npm/package-lock.json`)

##### What the CVE is
image-size ≤2.0.2 can be forced into an infinite loop in its ICNS parser. An ICNS buffer with valid magic bytes and a zero-valued entry-length field never advances the parser offset, so the `while` loop never terminates and permanently blocks the Node.js event loop — a denial of service against any service that parses attacker-supplied image data with this library.

##### How it appears in our code
`image-size@2.0.2` is **not a declared dependency** of EUID-docs. It is a transitive, build-time dependency of `@docusaurus/mdx-loader@3.9.2` (`package-lock.json:3360`, resolved at `:9931`). Docusaurus' MDX loader uses image-size to compute the intrinsic dimensions of images referenced in the documentation markdown during `docusaurus build`. The repo's `package.json` `overrides` pin `image-size@1` to `^1.2.1`, but that selector only constrains the v1 range and does not touch the v2.0.2 copy the loader pulls in — which is what the scanner reports.

##### Reachability
- EUID-docs is a **static documentation site** (Docusaurus). The build emits static HTML; there is no long-running Node service, no Express/HTTP server, and no runtime event loop that parses image input. (`grep` for `express`/`createServer`/`http.Server` in `src/` → nothing.)
- The only invocation of image-size is at **build time**, against **trusted, in-repo image assets** authored by the UID2 team — not attacker-controlled input.
- No `.icns` files exist in the repository, and no source file imports image-size directly.
- The CVE's threat model ("remote attackers … supplying a specially crafted ICNS buffer") requires untrusted input reaching the parser at runtime. That precondition does not exist here.

##### Decision
**not_affected.** The vulnerable ICNS code path is present in the dependency tree but is unreachable: it runs only during the static build over trusted inputs, with no runtime attack surface. Per decision logic, an unreachable path is suppressed regardless of whether a fixed version exists.

**Recommended action:** Suppress this finding for EUID-docs (repo-root `.trivyignore`). Optionally, a future dependency bump of Docusaurus/mdx-loader to a release depending on a patched image-size would clear it at source, but it is not security-required.

</details>

### CVE-2026-67213 — HIGH, `nanoid`

The CVE is a DoS via infinite loop in nanoid's customAlphabet/customRandom functions, triggered only when an application passes an unvalidated, attacker-controlled size of 0 to those specific functions. In EUID-docs, nanoid@3.3.16 is present purely as a transitive dependency of postcss, which is build-time tooling for the Docusaurus static-site generator. postcss invokes only the default nanoid() export to mint fixed-length internal identifiers; it never calls customAlphabet or customRandom, and no size value is derived from external input. No repo source code imports nanoid directly, and the project ships static HTML with no server runtime that could receive an attacker-controlled size. The vulnerable code path is therefore unreachable. Per decision logic, availability of a fixed version does not change a not_affected verdict.

<details>
<summary>Full triage report — CVE-2026-67213</summary>

#### CVE-2026-67213 — nanoid DoS via infinite loop (customAlphabet/customRandom, size=0)

**Severity:** HIGH (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H) — GHSA-2v37-7h3g-55p8

**Package:** nanoid 3.3.16 (installed) — fixed in 3.3.18 / 5.1.6

##### The vulnerability
nanoid before 5.1.6 contains an infinite loop in the `customAlphabet` and `customRandom` functions. When either is configured with a `size` of 0, the internal generation loop never satisfies its exit condition and spins indefinitely, hanging the calling thread. Exploitation requires an application to pass an **unvalidated, attacker-controlled size of 0** to one of these two specific functions. The default `nanoid()` generator is not affected.

##### Impact on EUID-docs
- **Presence:** nanoid@3.3.16 is pinned in `package-lock.json` solely as a transitive dependency of `postcss@8.5.18`. It is not a direct dependency in `package.json`, whose declared dependencies are all Docusaurus/React static-site build tooling.
- **Reachability:** No source file under `docs/` or `src/` imports nanoid or references `customAlphabet`/`customRandom` (grep returned no matches). The sole consumer, postcss, uses only the default `nanoid()` export to generate fixed-length internal identifiers; it never calls the vulnerable `customAlphabet`/`customRandom` functions and never derives a `size` from external input.
- **Runtime:** EUID-docs is a static Docusaurus documentation site (no Dockerfile, no server runtime). nanoid runs only at build time, with no path for an attacker to supply `size=0`.

##### Decision
**not_affected.** The vulnerable code path (customAlphabet/customRandom with attacker-controlled size=0) is unreachable in this repository. The recommended action is to **suppress** this finding in the repo-root `.trivyignore`. A fixed version exists but, per policy, its availability does not change a not_affected verdict; upgrading postcss/nanoid would be optional dependency hygiene rather than a required remediation.

</details>

### GHSA-5p4m-2wfm-xmqj — HIGH, `js-yaml`

The advisory describes a denial-of-service: resolveYamlOmap() enforces key uniqueness with an O(n²) linear scan, so parsing a modestly sized untrusted !!omap document burns disproportionate CPU inside yaml.load(). Exploitation therefore requires an attacker-controlled YAML input reaching yaml.load(). EUID-docs is a Docusaurus static-documentation site. The affected versions are indeed installed (overrides pin them exactly, and the lockfile confirms 4.3.0 at root plus 3.15.0 under gray-matter), so presence is not in dispute. But js-yaml is only invoked at build/lint time: Docusaurus and gray-matter parse the site's own markdown frontmatter and config, and eslint tooling parses config — all repo-authored, trusted content processed in CI. There is no Dockerfile, no runtime service, and no direct js-yaml import or yaml.load call in src/; the built output is static HTML served without any YAML parsing. With no source of untrusted YAML, the quadratic-CPU path is unreachable in the way this artifact is built and run. A fixed version exists, but per decision logic that does not change a not_affected verdict when the path is unreachable.

<details>
<summary>Full triage report — GHSA-5p4m-2wfm-xmqj</summary>

#### GHSA-5p4m-2wfm-xmqj — js-yaml quadratic CPU in `!!omap` resolution (EUID-docs)

**Severity:** HIGH (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H — availability only)
**Package:** js-yaml — installed 4.3.0 and 3.15.0
**Fixed in:** 4.3.1, 3.15.1

##### What the CVE is
`resolveYamlOmap()` enforces key uniqueness for `!!omap` sequences with a per-element linear scan (`objectKeys.indexOf(pairKey)` at `lib/type/omap.js`), making resolution O(n²) in the number of entries. A modestly sized untrusted YAML document parsed with a plain `yaml.load()` (the `!!omap` type is in the default schema) therefore consumes disproportionate CPU — a denial of service against any consumer that parses **untrusted** YAML. Same weakness as CVE-2026-59870, fixed in the 5.x line but never backported to 3.x/4.x.

##### Whether it affects us
EUID-docs is a Docusaurus static-documentation site. The vulnerable versions are genuinely present — `package.json` `overrides` pin `js-yaml@4` → `4.3.0` and `js-yaml@3` → `3.15.0`, and `package-lock.json` confirms both installed (4.3.0 at root under `@docusaurus/utils`, `plugin-content-docs`, `utils-validation`, and `eslint`; 3.15.0 nested under `gray-matter`). Presence is not in dispute.

Reachability is. Every js-yaml consumer here runs at **build or lint time**:
- Docusaurus and `gray-matter` parse the site's own markdown frontmatter and configuration.
- eslint tooling parses config files.

All of that YAML is repo-authored, trusted content processed in CI. There is no Dockerfile, no runtime server, and no direct `js-yaml` import, `require('js-yaml')`, or `yaml.load` call in `src/`. The build emits static HTML that is served without any YAML parsing. With no attacker-controlled YAML reaching `yaml.load()`, the quadratic-CPU DoS path cannot be exercised.

##### Decision
**not_affected.** The package and vulnerable code are present, but the attack vector (parsing untrusted YAML) has no corresponding input source in this static-site build. A fixed version exists, but that does not change the verdict when the path is unreachable — recommend suppressing this finding (repo-root `.trivyignore`). If a future change introduces runtime parsing of user-supplied YAML, revisit and upgrade to js-yaml 4.3.1 / 3.15.1.

</details>

---
_Opened by uid2-vul-scan-agent (general_use_claude-opus-4-8) for the automated finding(s) above. Verdict confidence: high. Please sanity-check each reachability argument before approving._
